### PR TITLE
Dev

### DIFF
--- a/src/lib/aloha/selection.js
+++ b/src/lib/aloha/selection.js
@@ -241,7 +241,7 @@ function(jQuery, FloatingMenu) {
 			this.inselection = false;
 
 			// before getting the selection tree, we do a cleanup
-			if (GENTICS.Utils.Dom.doCleanup({'mergetext' : true}, rangeObject)) {
+			if (GENTICS.Utils.Dom.doCleanup({'merge' : true}, rangeObject)) {
 				this.rangeObject.update();
 				this.rangeObject.select();
 			}
@@ -925,7 +925,7 @@ function(jQuery, FloatingMenu) {
 
 			// merge text nodes
 
-			GENTICS.Utils.Dom.doCleanup({'mergetext' : true}, this.rangeObject);
+			GENTICS.Utils.Dom.doCleanup({'merge' : true}, this.rangeObject);
 			// update the range and select it
 			this.rangeObject.update();
 			this.rangeObject.select();


### PR DESCRIPTION
Fixes Gentics Support Ticket #43496 - splitting, joining, splitting causes text to be lost

Let there be a paragraph, or another splittable element that contains
text. Let the element be split in the middle of the contained text - the
result will be two elements, each of which containing part of the
splitted text.

Let the two elements be joined again with backspace - on IE7 the result
will be one element that contains two text nodes.

On IE7, if the splittable element with two text nodes was split again,
the second text node was lost.
