### PR TITLE
Dev

### DIFF
--- a/src/lib/aloha/core.js
+++ b/src/lib/aloha/core.js
@@ -308,7 +308,7 @@ function (jQuery, PluginManager, FloatingMenu, undefined) {
 			}
 
 			// register the body click event to blur editables
-			jQuery('html').mousedown(function() {
+			jQuery('html').mousedown(function(e) {
 				// if an Ext JS modal is visible, we don't want to loose the focus on
 				// the editable as we assume that the user must have clicked somewhere
 				// in the modal... where else could he click?
@@ -316,11 +316,13 @@ function (jQuery, PluginManager, FloatingMenu, undefined) {
 				// column/row deletion, as the table module will clean it's selection
 				// as soon as the editable is deactivated. Fusubscriberthermore you'd have to
 				// refocus the editable again, which is just strange UX
-				if (Aloha.activeEditable && !Aloha.isMessageVisible()) {
+				if (Aloha.activeEditable && !Aloha.isMessageVisible() && !Aloha.eventHandled) {
 					Aloha.activeEditable.blur();
 					FloatingMenu.setScope('Aloha.empty');
 					Aloha.activeEditable = null;
 				}
+			}).mouseup(function(e) {
+				Aloha.eventHandled = false;
 			});
 			// Initialise the base path to the aloha files
 			Aloha.settings.base =

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -154,7 +154,15 @@ function(jQuery, PluginManager, FloatingMenu) {
 
 				// add focus event to the object to activate
 				me.obj.mousedown(function(e) {
-					return me.activate(e);
+					// check whether the mousedown was already handled
+					if (!Aloha.eventHandled) {
+						Aloha.eventHandled = true;
+						return me.activate(e);
+					}
+				});
+
+				me.obj.mouseup(function(e) {
+					Aloha.eventHandled = false;
 				});
 
 				me.obj.focus(function(e) {
@@ -534,11 +542,6 @@ function(jQuery, PluginManager, FloatingMenu) {
 		 * @method
 		 */
 		activate: function(e) {
-			// stop event propagation for nested editables
-			if (e) {
-				e.stopPropagation();
-			}
-
 			// get active Editable before setting the new one.
 			var oldActive = Aloha.getActiveEditable();
 
@@ -559,11 +562,6 @@ function(jQuery, PluginManager, FloatingMenu) {
 
 			// set active Editable in core
 			Aloha.activateEditable( this );
-
-			// ie specific: trigger one mouseup click to update the range-object
-			if (document.selection && document.selection.createRange) {
-				this.obj.mouseup();
-			}
 
 			// Placeholder handling
 			this.removePlaceholder(this.obj, true);

--- a/src/lib/aloha/floatingmenu.js
+++ b/src/lib/aloha/floatingmenu.js
@@ -1,6 +1,6 @@
 /*!
 * This file is part of Aloha Editor Project http://aloha-editor.org
-* Copyright © 2010-2011 Gentics Software GmbH, aloha@gentics.com
+* Copyright ï¿½ 2010-2011 Gentics Software GmbH, aloha@gentics.com
 * Contributors http://aloha-editor.org/contribution.php 
 * Licensed unter the terms of http://www.aloha-editor.org/license.html
 *//*
@@ -543,6 +543,10 @@ function(jQuery, Ext, Base, undefined) {
 				.html('&#160;')
 				.mousedown(function (e) {
 					that.togglePin();
+					// Note: this event is deliberately stopped here, although normally,
+					// we would set the flag GENTICS.Aloha.eventHandled instead.
+					// But when the event bubbles up, no tab would be selected and
+					// the floatingmenu would be rather thin.
 					e.stopPropagation();
 				});
 
@@ -585,16 +589,17 @@ function(jQuery, Ext, Base, undefined) {
 			// for now, position the panel somewhere
 			this.extTabPanel.setPosition(this.left, this.top);
 
-			// disable event bubbling for mousedown, because we don't want to recognize
+			// mark the event being handled by aloha, because we don't want to recognize
 			// a click into the floatingmenu to be a click into nowhere (which would
 			// deactivate the editables)
 			this.obj.mousedown(function (e) {
 				e.originalEvent.stopSelectionUpdate = true;
-				e.stopPropagation();
+				Aloha.eventHandled = true;
 		//		e.stopSelectionUpdate = true;
 			});
 			this.obj.mouseup(function (e) {
 				e.originalEvent.stopSelectionUpdate = true;
+				Aloha.eventHandled = false;
 			});
 
 			// adjust float behaviour

--- a/src/lib/aloha/ui-attributefield.js
+++ b/src/lib/aloha/ui-attributefield.js
@@ -85,10 +85,6 @@ Ext.ux.AlohaAttributeField = Ext.extend(Ext.form.ComboBox, {
 			}
 		},
 		'afterrender': function (obj, event) {
-			var that = this;
-			jQuery(this.wrap.dom.children[0]).blur(function(e){
-				that.triggerBlur();
-			});
 			jQuery(this.wrap.dom.children[0]).css("color", "#AAA");
 			this.setValue(this.placeholder);
 		},
@@ -157,16 +153,40 @@ Ext.ux.AlohaAttributeField = Ext.extend(Ext.form.ComboBox, {
 				this.setValue(this.placeholder);
 			}
 		},
+		'hide': function(obj, event) {
+		// remove the highlighting and restore original color if was set before
+			var
+				target = jQuery(this.getTargetObject()),
+				color;
+
+			if ( target ) {
+				color = target.attr('data-original-background-color');
+				if ( color ) {
+					jQuery(target).css('background-color', color);
+				} else {
+					jQuery(target).css('background-color', '');
+				}
+				jQuery(target).removeAttr('data-original-background-color');
+			}
+			if (this.getValue() === '') {
+				jQuery(this.wrap.dom.children[0]).css("color", "#AAA");
+				this.setValue(this.placeholder);
+			}
+		},
 		'expand': function (combo ) {
 			if( this.noQuery ) {
 				this.collapse();
 			}
 			if (!this.clickAttached) {
 				var that = this;
-				// attach the missing mousedown event to be able to select autocomplete items by clicking on them
+				// attach the mousedown event to set the event handled,
+				// so that the editable will not get deactivated
 				this.mon(this.innerList, 'mousedown', function (event) {
-					this.onViewClick(true); // select the item that has been clicked
-					event.stopEvent(); // stop floating menu from closing
+					Aloha.eventHandled = true;
+				}, this);
+				// in the mouseup event, the flag will be reset
+				this.mon(this.innerList, 'mouseup', function (event) {
+					Aloha.eventHandled = false;
 				}, this);
 				this.clickAttached = true;
 			}


### PR DESCRIPTION
Fixed handling of mousedown events into aloha controls or editables: instead of stopping event propagation (which could break ui functionality like Ext JS), a global flag is set to avoid deactivation of editables when clicking into the floatingmenu, editables, attributefields... With this change, it should now be possible to use the scrollbar of the Ext JS ComboBox with the mouse.
