### PR TITLE
Fixed issue #269

### DIFF
--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -204,6 +204,11 @@ function(Aloha, Class, jQuery, PluginManager, FloatingMenu, Selection, Markup) {
 
 				me.snapshotContent = me.getContents();
 
+				// FF bug: check for empty editable contents (no <br>; no whitespace) see: 
+				if (jQuery.browser.mozilla) {
+					me.initEmptyEditable();
+				}
+
 				// init placeholder
 				me.initPlaceholder();
 
@@ -338,6 +343,20 @@ function(Aloha, Class, jQuery, PluginManager, FloatingMenu, Selection, Markup) {
 				return true;
 			} else {
 				return false;
+			}
+		},
+
+		/**
+		 * Check if the editable div is not empty. Fixes a FF browser bug
+		 * see issue: https://github.com/alohaeditor/Aloha-Editor/issues/269
+		 *
+		 * @return void
+		 */
+		initEmptyEditable: function() {
+			var obj = this.obj;
+			
+			if (this.empty(this.getContents())) {
+				jQuery(obj).prepend('<br class="aloha-cleanme" />');
 			}
 		},
 


### PR DESCRIPTION
Firefox bug with empty contenteditable -- see https://github.com/alohaeditor/Aloha-Editor/issues/269 (not depended on Aloha)
