### PR TITLE
prevent default buttons from being clicked when pressing enter in ui-attr

### DIFF
--- a/src/lib/aloha/ui-attributefield.js
+++ b/src/lib/aloha/ui-attributefield.js
@@ -132,6 +132,7 @@ Ext.ux.AlohaAttributeField = Ext.extend(Ext.form.ComboBox, {
 				} else {
 					this.ALOHAwasExpanded = false;
 				}
+				event.preventDefault();
 			}
 		},
 		'keyup': function (obj, event) {


### PR DESCRIPTION
prevent default buttons from being clicked when pressing enter in ui-attribute field
