### PR TITLE
Dev

### DIFF
--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -226,7 +226,10 @@ function(Aloha, Plugin, jQuery, FloatingMenu, i18n, i18nCore) {
 
 			// on blur check if href is empty. If so remove the a tag
 			this.hrefField.addListener('blur', function(obj, event) {
-				if ( !this.getValue() ) {
+				//checks for either a literal value in the href field
+				//(that is not the pre-filled "http://") or a resource
+				//(e.g. in the case of a repository link)
+				if ( ( ! this.getValue() || this.getValue() === "http://" ) && ! this.getItem() ) {
 					that.removeLink();
 				}
 			});


### PR DESCRIPTION
The link plugin will automatically remove a link if no text was entered
in the ui-attributefield.

Links that are entered literally in the ui-attributefield worked
flawlessly. Links arrvied at through a link repository, however, were
removed as soon as one left the ui-attributefield (blur), since there
was no check for whether a resource was entered.
