### PR TITLE
Implements the dom-to-xhtml plugin

### DIFF
--- a/src/lib/aloha.js
+++ b/src/lib/aloha.js
@@ -1,3 +1,4 @@
+
 /** vim: et:ts=4:sw=4:sts=4
  * @license RequireJS 0.26.0+ Copyright (c) 2010-2011, The Dojo Foundation All Rights Reserved.
  * Available via the MIT or new BSD license.
@@ -3007,9 +3008,6 @@ jQuery.extend({
 							while( callbacks[ 0 ] ) {
 								callbacks.shift().apply( context, args );
 							}
-						}
-						catch(e) {
-							// damn you IE <= 7
 						}
 						finally {
 							fired = [ context, args ];
@@ -61124,171 +61122,208 @@ Ext.grid.GroupingView.GROUP_ID = 1000;
 * You should have received a copy of the GNU Affero General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
-(function(){
-
-	// load jQuery with noConflict (true ) to remove anyway from global namespace
+( function () {
+	'use strict'
+	
+	// load jQuery with noConflict (true) to remove anyway from global namespace
 	// a user may add it by its own with var jQuery = $ = Aloha.jQuery;
 	var 
-		jQuery = window.jQuery.noConflict( true ),
-		deferredReady,
-		alohaRequire;
+	    jQuery = window.jQuery.noConflict( true ),
+	    deferredReady,
+	    alohaRequire;
 	
 	// Ensure Aloha settings namespace and default
 	window.Aloha = window.Aloha || {};
-
+	
 	// reset defaults. Users should use settings. 
 	Aloha.defaults = {};
-
+	
 	// guarantee the settings namespace even if not set by user
 	Aloha.settings = Aloha.settings || {};
-
+	
 	// set jQuery to buildin of not otherwise set
 	// From here on Aloha.jQuery is always available
-	Aloha.jQuery = Aloha.settings.jQuery || Aloha.jQuery || jQuery|| null;
-
+	Aloha.jQuery = Aloha.settings.jQuery || Aloha.jQuery || jQuery || null;
+	
 	// Aloha define, require, preserve original require
 	Aloha._require = require;
 	Aloha.define = define;
 	
-	// Determs the base path of Aloha Editor which is supposed to be the path of aloha.js (this file)
+	// Determins the base path of Aloha Editor which is supposed to be the path of aloha.js (this file)
 	Aloha.settings.baseUrl = Aloha.settings.baseUrl || getBaseUrl();
 	
 	// aloha base path is defined by a script tag with the data attribute 
 	// data-aloha-plugins and the filename aloha.js
 	// no jQuery at this stage...
-	function getBaseUrl() {
-		
+	function getBaseUrl () {
 		var
-			baseUrl = './',
-			i,
-			script,
-			scripts = document.getElementsByTagName("script"),
-			regexAlohaJs = /\/aloha.js$/,
-			regexJs = /[^\/]*\.js$/;
+		    baseUrl = './',
+		    script,
+		    scripts = document.getElementsByTagName( 'script' ),
+		    i, j = scripts.length,
+		    regexAlohaJs = /\/aloha.js$/,
+		    regexJs = /[^\/]*\.js$/;
 		
-        for ( i = 0; i < scripts.length && ( script = scripts[i] ); ++i ) {
-        	
-            // take aloha.js or first ocurrency of data-aloha-plugins 
-        	// and script ends with .js
-        	if ( regexAlohaJs.test( script.src ) ) {
-        		baseUrl = script.src.replace( regexAlohaJs , '' );
-        		break;
-        	}            
-            if ( baseUrl === './' && script.getAttribute( 'data-aloha-plugins')
-            		&& regexJs.test(script.src ) ) {
-            	baseUrl = script.src.replace( regexJs , '' );
-            }
-        }
+		for ( i = 0; i < j && ( script = scripts[ i ] ); ++i ) {
+			// take aloha.js or first ocurrency of data-aloha-plugins 
+			// and script ends with .js
+			if ( regexAlohaJs.test( script.src ) ) {
+				baseUrl = script.src.replace( regexAlohaJs , '' );
+				break;
+			}            
+			if ( baseUrl === './' && script.getAttribute( 'data-aloha-plugins' )
+				&& regexJs.test(script.src ) ) {
+				baseUrl = script.src.replace( regexJs , '' );
+			}
+		}
         
 		return baseUrl;
 	};
-
+	
 	// prepare the require config object and remember it
 	Aloha.settings.requireConfig = {
-			context: 'aloha',
-			baseUrl: Aloha.settings.baseUrl,
-			locale: Aloha.settings.locale
+		context: 'aloha',
+		baseUrl: Aloha.settings.baseUrl,
+		locale: Aloha.settings.locale
 	};
 	
 	// configure require and expose the Aloha.require function
 	alohaRequire = require.config( Aloha.settings.requireConfig );
-	Aloha.require = function( callback ) {
-		
+	Aloha.require = function ( callback ) {
 		// passes the Aloha object to the passed callback function
 		if ( arguments.length == 1 && typeof callback === 'function' ) {
-			return alohaRequire( ['aloha'], callback );
+			return alohaRequire( [ 'aloha' ], callback );
 		}
 		return alohaRequire.apply( this, arguments );
 	};
 	
 	// create promise for 'aloha-ready' when Aloha is not yet ready
-    // and fire later when 'aloha-ready' is triggered all other events bind
+	// and fire later when 'aloha-ready' is triggered all other events bind
 	deferredReady = Aloha.jQuery.Deferred();
-    Aloha.bind = function( type, fn ) {
-    	if ( type == 'aloha-ready' ) {
-    		if ( Aloha.stage != 'alohaReady' ) {
-    			deferredReady.done( fn );
-    		} else {
-    			fn();
-    		}
-    	} else {
-    		Aloha.jQuery( Aloha, 'body' ).bind( type, fn );
-    	}
-    	return this;
-    };
+	Aloha.bind = function ( type, fn ) {
+		if ( type == 'aloha-ready' ) {
+			if ( Aloha.stage != 'alohaReady' ) {
+				deferredReady.done( fn );
+			} else {
+				fn();
+			}
+		} else {
+			Aloha.jQuery( Aloha, 'body' ).bind( type, fn );
+		}
 	
-    Aloha.trigger = function( type, data ) {
-    	if ( type == 'aloha-ready' ) {
-    		// resolve all deferred events on dom ready and delete local var
-    		Aloha.jQuery( deferredReady.resolve );
-    	}
-    	Aloha.jQuery( Aloha, 'body' ).trigger( type, data );
-    	return this;
-    };
-    
-	Aloha.ready = function( fn ) {
-    	this.bind('aloha-ready', fn);
-    	return this;
+		return this;
 	};
-}());
+	
+	Aloha.trigger = function ( type, data ) {
+		if ( type == 'aloha-ready' ) {
+			// resolve all deferred events on dom ready and delete local var
+			Aloha.jQuery( deferredReady.resolve );
+		}
+		Aloha.jQuery( Aloha, 'body' ).trigger( type, data );
+		return this;
+	};
+	
+	Aloha.ready = function ( fn ) {
+		this.bind( 'aloha-ready', fn );
+		return this;
+	};
+	
+	// Async Module Dependency error handling
+	// Aloha will intercept RequireJS errors in order to facilitate more
+	// flexible and more graceful degredation where possible
+	( function ( origOnError ) {
+		 require.onError = function ( err ) {
+			var fatalTimeouts = [];
+			var failedModules = Aloha.jQuery.trim( err.requireModules )
+									 .split( ' ' );
+			
+			for ( var i = 0; i < failedModules.length; i++ ) {
+				switch ( err.requireType ) {
+				case 'timeout':
+					// We only catch failures which do not rise from Aloha core
+					// files. If a core file fails to load properly, it is
+					// always a fatal error.
+					if ( !/^aloha\/.+/.test( failedModules[ i ] ) ) {
+						if ( window.console &&
+								typeof window.console.error === 'function' ) {
+							window.console.error( 'Aloha-Editor Error: ' +
+								'The following module failed to load: ' +
+								failedModules[ i ] );
+						}
+					} else {
+						fatalTimeouts.push( failedModules[ i ] );
+					}
+					break;
+				default:
+					// "timeout" is currently, the only defined
+					// err.requireType . But in case of any future custom
+					// err.requireType which we do not handle, we will pass it
+					// back to the original require.onError function.
+					origOnError.apply( {}, arguments );
+				}
+			}
+			
+			throw 'Aloha-Editor Exception: The following core file' +
+				( fatalTimeouts.length ? 's have' : ' has' ) +
+				' timed-out while loading: ' + fatalTimeouts.join( ', ' );
+		};
+	} )( require.onError );
+	
+} )();
 
 // define aloha object
-define( 'aloha', [], function(){
+define( 'aloha', [], function () {
 	return Aloha;
-});
+} );
 
-//Aloha.jQuery( function() {
-	//load Aloha dependencies
-	require( 
-		Aloha.settings.requireConfig, 
-		[
-			'aloha/jquery',
-			'aloha/ext',
-		],
-		function() {
-			
-			// load Aloha core files
-			require(
-				Aloha.settings.requireConfig, 
-				[
-					'vendor/jquery.json-2.2.min',
-					'vendor/jquery.store',
-					'aloha/rangy-core',
-					'util/json2',
-					'util/class',
-					'util/lang',
-					'util/range',
-					'util/dom',
-					'aloha/core',
-					'aloha/editable',
-					'aloha/console',
-					'aloha/markup',
-					'aloha/message',
-					'aloha/plugin',
-					'aloha/selection',
-					'aloha/command',
-					'aloha/jquery.patch',
-					'aloha/jquery.aloha',
-					'aloha/sidebar',
-					'util/position',
-					'aloha/ext-alohaproxy',
-					'aloha/ext-alohareader',
-					'aloha/ext-alohatreeloader',
-					'aloha/ui',
-					'aloha/ui-attributefield',
-					'aloha/ui-browser',
-					'aloha/floatingmenu',
-					'aloha/repositorymanager',
-					'aloha/repository',
-					'aloha/repositoryobjects',
-					'aloha/contenthandlermanager'
-				],
-				function() {
-					
-					// jQuery calls the init method when the dom is ready
-					Aloha.jQuery( Aloha.init );
-				}
-			);
-		}
-	);
-//});
+//load Aloha dependencies
+require( 
+	Aloha.settings.requireConfig, 
+	[
+		'aloha/jquery',
+		'aloha/ext',
+	],
+	function () {
+		// load Aloha core files
+		require(
+			Aloha.settings.requireConfig, 
+			[
+				'vendor/jquery.json-2.2.min',
+				'vendor/jquery.store',
+				'aloha/rangy-core',
+				'util/json2',
+				'util/class',
+				'util/lang',
+				'util/range',
+				'util/dom',
+				'aloha/core',
+				'aloha/editable',
+				'aloha/console',
+				'aloha/markup',
+				'aloha/message',
+				'aloha/plugin',
+				'aloha/selection',
+				'aloha/command',
+				'aloha/jquery.patch',
+				'aloha/jquery.aloha',
+				'aloha/sidebar',
+				'util/position',
+				'aloha/ext-alohaproxy',
+				'aloha/ext-alohareader',
+				'aloha/ext-alohatreeloader',
+				'aloha/ui',
+				'aloha/ui-attributefield',
+				'aloha/ui-browser',
+				'aloha/floatingmenu',
+				'aloha/repositorymanager',
+				'aloha/repository',
+				'aloha/repositoryobjects',
+				'aloha/contenthandlermanager'
+			],
+			function () {
+				// jQuery calls the init method when the dom is ready
+				Aloha.jQuery( Aloha.init );
+			}
+		);
+	}
+);

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -52,6 +52,12 @@ define( [
 		Aloha.settings.contentHandler = {};
 	}
 
+	var defaultContentSerializer = function(editableElement){
+		return jQuery(editableElement).html();
+	};
+
+	var contentSerializer = defaultContentSerializer;
+
 	/**
 	 * Editable object
 	 * @namespace Aloha
@@ -693,19 +699,7 @@ define( [
 			this.removePlaceholder( clonedObj );
 			PluginManager.makeClean( clonedObj );
 
-			/*
-			//also deactivated for now. like initEditable. just in case ...
-			var content = clonedObj.html()
-			if ( typeof Aloha.settings.contentHandler.getContents === 'undefined' ) {
-				Aloha.settings.contentHandler.getContents = Aloha.defaults.contentHandler.getContents;
-			}
-			content = ContentHandlerManager.handleContent( content, {
-				contenthandler: Aloha.settings.contentHandler.getContents
-			} );
-			clonedObj.html( content );
-			*/
-
-			return asObject ? clonedObj.contents() : clonedObj.html();
+			return asObject ? clonedObj.contents() : contentSerializer(clonedObj[0]);
 		},
 
 		/**
@@ -861,6 +855,24 @@ define( [
 			this.snapshotContent = this.getContents();
 			return ret;
 		}
-
 	} );
+
+	/**
+	 * Sets the serializer function to be used for the contents of all editables.
+	 *
+	 * The default content serializer will just call the jQuery.html()
+	 * function on the editable element (which gets the innerHTML property).
+	 *
+	 * This method is a static class method and will affect the result
+	 * of editable.getContents() for all editables that have been or
+	 * will be constructed.
+	 *
+	 * @param serializerFunction
+	 *        A function that accepts a DOM element and returns the serialized
+	 *        XHTML of the element contents (excluding the start and end tag of
+	 *        the passed element).
+	 */
+	Aloha.Editable.setContentSerializer = function( serializerFunction ) {
+		contentSerializer = serializerFunction;
+	};
 } );

--- a/src/plugins/common/dom-to-xhtml/lib/dom-to-xhtml-plugin.js
+++ b/src/plugins/common/dom-to-xhtml/lib/dom-to-xhtml-plugin.js
@@ -1,0 +1,29 @@
+/*!
+* Aloha Editor
+* Author & Copyright (c) 2010 Gentics Software GmbH
+* aloha-sales@gentics.com
+* Licensed unter the terms of http://www.aloha-editor.com/license.html
+*/
+/**
+ * The dom-to-xhtml plugin extends the serialization method of the
+ * Aloha.Editable.getContent() instance method to generate valid XHTML
+ * (in so far as the DOM of the editables itself is valid).
+ */
+define(
+['aloha', 'aloha/jquery', 'aloha/plugin', 'dom-to-xhtml/dom-to-xhtml'],
+function( Aloha, $, Plugin, domToXhtml) {
+	"use strict";
+
+	return Plugin.create('dom-to-xhtml', {
+		/**
+		 * Called by the plugin-manager on intialization.
+		 *
+		 * @Override
+		 */
+		init: function () {
+			Aloha.Editable.setContentSerializer(function(editableElement){
+				return domToXhtml.contentsToXhtml(editableElement);
+			});
+		}
+	});
+});

--- a/src/plugins/common/dom-to-xhtml/lib/dom-to-xhtml.js
+++ b/src/plugins/common/dom-to-xhtml/lib/dom-to-xhtml.js
@@ -1,0 +1,344 @@
+/*!
+* Aloha Editor
+* Author & Copyright (c) 2010 Gentics Software GmbH
+* aloha-sales@gentics.com
+* Licensed unter the terms of http://www.aloha-editor.com/license.html
+*/
+/**
+ * Provides public utility methods to convert DOM nodes to XHTML.
+ */
+define(
+['aloha', 'aloha/jquery', 'aloha/console'],
+function( Aloha, $, console) {
+	"use strict";
+
+	/**
+	 * Gets the attributes of the given element.
+	 *
+	 * @param element
+	 *        An element to get the attributes for.
+	 * @return
+	 *        An array of consisting of [name, value] tuples for each attribute.
+	 *        Attribute values may be strings, booleans or undefined.
+	 */
+	function getAttrs(element) {
+		var attrs = element.attributes;
+		var cleanAttrs = [];
+		var elementName = element.nodeName;
+		for (var i = 0; i < attrs.length; i++) {
+			var name  = attrs[i].nodeName;
+			if ($.browser.msie) {
+				// attrs[i].nodeValue would stringify the object; getAttribute doesn't.
+				var value = element.getAttribute(name);
+				if (
+					// The check for not null and not undefined is required to exclude most of
+					// the 84 attributes that are always defined for IE7.
+				       null == value
+					// In IE, some attributes are reported with non-null default
+					// values, even if the attribute isn't set on the element.
+					// More of these attributes appear in IE7 than in IE8.
+					|| 'tabIndex' == name && 0 === value
+					|| 'contentEditable' == name && 'inherit' === value
+					|| 'hideFocus' == name && false === value
+					|| 'disabled' == name && false === value
+					|| 'compact' == name && false === value
+					|| 'noWrap' == name && false === value //div, th
+					|| ('INPUT' == elementName || 'IMG' == elementName)
+						&& (   ('start' == name && 'fileopen' == value)
+							|| ('hspace' == name && 0 === value)
+							|| ('maxLength' == name && 2147483647 === value)
+							|| ('indeterminate' == name && false === value)
+							|| ('vspace' == name && 0 === value)
+						    || ('loop' == name && 1 === value) )
+					// ordered lists start with 1 by default
+					|| 'OL' == elementName && 'start' == name && 1 === value
+					|| 'IMG' == elementName && ('isMap' == name || 'loop' == name) && false === value
+					|| 'TABLE' == elementName && ('cols' == name || 'dataPageSize' == name) && 0 === value
+					|| 'LI' == elementName && 'value' == name && 0 === value
+					|| ('TH' == elementName || 'TD' == elementName) && ('colSpan' == name || 'rowSpan' == name) && 1 == value) {
+					continue;
+				}
+				// IE sets the attribute value="on" when a checkbox is checked, and ignores the "checkbox" attribute.
+				// Setting value="on" will not make the checkbox checked (Chrome).
+				if ('INPUT' == elementName && 'value' == name && 'on' == value) {
+					var type = element.type.toLowerCase();
+					if ('checkbox' == type || 'radio' == type) {
+						cleanAttrs.push(['checked', 'checked']);
+						continue;
+					}
+				}
+			}
+			cleanAttrs.push([name, $.attr(element, name)]);
+		}
+		return cleanAttrs;
+	}
+
+	/**
+	 * Elements that are to be serialized like <img /> and not like <img></img>
+	 */
+	var emptyElements = [
+		"area", "base", "basefont", "br", "col", "frame", "hr",
+		"img", "input", "isindex", "link", "meta", "param", "embed" ];
+
+	/**
+	 * Attributes that are to be serialized like checked="checked" for any true attribute value.
+	 */
+	var booleanAttrs = [
+		"checked", "compact", "declare", "defer", "disabled", "ismap", "multiple",
+		"nohref", "noresize", "noshade", "nowrap", "readonly", "selected" ];
+
+	/**
+	 * Encodes a string meant to be used wherever parsable character data occurs in XML.
+	 * @param str
+	 *        An unencoded piece of character data
+	 * @return
+	 *        The given string with & and < characters replaced with the corresponding HTML entity references.
+	 */
+	function encodePcdata(str) {
+		return str.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+	}
+
+	/**
+	 * Encodes a string meant to be used between double-quoted attribute values.
+	 *
+	 * @param str
+	 *        An unencoded attribute value
+	 * @return
+	 *        The given string with & < and " characters replaced with the corresponding HTML entity references.
+	 */
+	function encodeDqAttrValue(str) {
+		return encodePcdata(str).replace(/"/g, '&quot;');
+	}
+
+	/**
+	 * Serializes the attributes of the given element.
+	 *
+	 * Attributes that have the empty string as value will not appear in the string at all.
+	 *
+	 * @param element
+	 *        An element to serialize the attributes of
+	 * @return
+	 *        A string made up of name="value" for each attribute of the
+	 *        given element, separated by space. The string will have a leading space.
+	 */
+	function makeAttrString(element) {
+		var attrs = getAttrs(element);
+		var str = "";
+		for (var i = 0; i < attrs.length; i++) {
+			var name  = attrs[i][0];
+			var value = attrs[i][1];
+			if ( "" === value || null == value ) {
+				// I don't think it is ever an error to make an
+				// attribute not appear if its string value is empty.
+				// This works around an IE8 bug, for example, where the
+				// "shape" attribute is reported to appear on "a"
+				// elements with an empty string value, even if it was
+				// never set.
+				continue;
+			}
+			//TODO it's only a boolean attribute if the element is in an HTML namespace
+			var isBool = (-1 !== $.inArray(name.toLowerCase(), booleanAttrs));
+			if ( ! isBool || (isBool && value) ) {
+				str += " " + name + '="' + encodeDqAttrValue( "" + (isBool ? name : value) ) + '"';
+			}
+		}
+		return str;
+	}
+
+	/**
+	 * IE8 turns the following
+	 * <book id="x">{content}</book>
+	 * into
+	 * <book id="x"></book>{content}</book><//book>
+	 * This seems to occur with any element IE doesn't recognize.
+	 *
+	 * @param element
+	 *        An element node.
+	 * @return
+	 *        true if the given element isn't recognized by IE and
+	 *        causes a broken DOM structure as outlined above.
+	 */
+	function isUnrecognized(element) {
+		var closingName = "/" + element.nodeName;
+		var sibling = element.nextSibling;
+		while (null != sibling) {
+			if (closingName == sibling.nodeName) {
+				return true;
+			}
+			sibling = sibling.nextSibling;
+		}
+		return false;
+	}
+
+	/**
+	 * Serializes the children of the given element into an XHTML string.
+	 *
+	 * The same as serializeElement() except it only serializes the children.
+	 * The start and end tag of the given element will not appear in the resulting XHTML.
+	 *
+	 * @see serializeElement()
+	 */
+	function serializeChildren(element, child, unrecognized, xhtml) {
+		while (null != child) {
+			if (1 === child.nodeType && unrecognized && "/" + element.nodeName == child.nodeName) {
+				child = child.nextSibling;
+				break;
+			} else if (1 === child.nodeType && isUnrecognized(child)) {
+				child = serializeElement(child, child.nextSibling, true, xhtml);
+			} else {
+				serialize(child, xhtml);
+				child = child.nextSibling;
+			}
+		}
+		return child;
+	}
+
+	/**
+	 * Serializes an element into an XHTML string.
+	 *
+	 * @param element
+	 *        An element to serialize.
+	 * @param child
+	 *        The first child of the given element. This will usually be
+	 *        element.firstChild. On IE this may be element.nextSibling because
+	 *        of the broken DOM structure IE sometimes generates.
+	 * @param unrecognized
+	 *        Whether the given element is unrecognized on IE. If IE doesn't
+	 *        recognize the element, it will create a broken DOM structure
+	 *        which has to be compensated for. See isUnrecognized() for more.
+	 * @param xhtml
+	 *        An array which receives the serialized element and whic, if joined,
+	 *        will yield the XHTML string.
+	 * @return
+	 *        null if all siblings of the given child have been processed as children
+	 *        of the given element, or otherwise the first sibling of child that is not considered
+	 *        a child of the given element.
+	 */
+	function serializeElement(element, child, unrecognized, xhtml) {
+		// TODO: we should only lowercase element names if they are in an HTML namespace
+		var elementName = element.nodeName.toLowerCase();
+		// This is a hack around an IE bug which strips the namespace prefix
+		// of element.nodeName if it occurs inside an contentEditable=true.
+		if (element.scopeName && 'HTML' != element.scopeName && -1 === elementName.indexOf(':')) {
+			elementName = element.scopeName.toLowerCase() + ':' + elementName;
+		}
+		if ( ! unrecognized && null == child && -1 !== $.inArray(elementName, emptyElements) ) {
+			xhtml.push('<' + elementName + makeAttrString(element) + '/>');
+		} else {
+			xhtml.push('<' + elementName + makeAttrString(element) + '>');
+			child = serializeChildren(element, child, unrecognized,  xhtml);
+			xhtml.push('</' + elementName + '>');
+		}
+		return child;
+	}
+
+	/**
+	 * Serializes a DOM node into a XHTML string.
+	 *
+	 * @param node
+	 *        A DOM node to serialize.
+	 * @param xhtml
+	 *        An array that will receive snippets of XHTML,
+	 *        which if joined will yield the XHTML string.
+	 */
+	function serialize(node, xhtml) {
+		var nodeType = node.nodeType;
+		if (1 === nodeType) {
+			serializeElement(node, node.firstChild, isUnrecognized(node), xhtml);
+		} else if (3 === node.nodeType) {
+			xhtml.push(encodePcdata(node.nodeValue));
+		} else if (8 === node.nodeType) {
+			xhtml.push('<' + '!--' + node.nodeValue + '-->');
+		} else {
+			console.log('Unknown node type encountered during serialization, ignoring it:'
+						+ ' type=' + node.nodeType
+						+ ' name=' + node.nodeName
+						+ ' value=' + node.nodeValue);
+		}
+	}
+	
+	return {
+		/**
+		 * Serializes a number of DOM nodes in an array-like object to an XHTML string.
+		 *
+		 * The XHTML of the nodes in the given array-like object will be concatenated.
+		 *
+		 * @param nodes
+		 *        An array or jQuery object or another array-like object to serialize.
+		 * @return
+		 *        The serialized XHTML String representing the given DOM nodes in the given array-like object.
+		 *        The result may look like an XML fragment with multiple top-level elements and text nodes.
+		 * @see nodeToXhtml()
+		 */
+		contentsToXhtml: function(element) {
+			var xhtml = [];
+			serializeChildren(element, element.firstChild, false, xhtml);
+			return xhtml.join("");
+		},
+
+		/**
+		 * Serializes a DOM node to an XHTML string.
+		 *
+		 * Beware that the serialization method will generate XHTML as
+		 * close as possible to the DOM tree represented by the given
+		 * node. The result will only be valid XHTML if the DOM tree
+		 * doesn't violate any contained-in rules.
+		 *
+		 * Element attributes with an empty string as value will not
+		 * appear in the serialized output.
+		 *
+		 * Element attribute names are case-insensitive in HTML5, so
+		 * they may come out in mixed-case depending on what the browser
+		 * provides.
+		 *
+		 * When iterating over the DOM, CDATA sections are comment nodes
+		 * on some browsers (Chrome) and not there at all on others (IE).
+		 * This is the same as what comes out from element.innerHTML.
+		 *
+		 * IE8 bug: comments will sometimes be silently stripped inside
+		 * contentEditable=true. Conditional includes don't work inside
+		 * contentEditable=true. See the tests for more information.
+		 *
+		 * IE8 bug: a title element will not be serialized correctly
+		 * unless it occurs in the head of a HTML document, even if it occurs
+		 * in a non-HTML namespace (maybe it works with a prefix).
+		 * This will probably also apply for other HTML elements that
+		 * occur in the header.
+		 *
+		 * IE8 bug: unrecognized elements in the HTML scope will cause
+		 * broken DOM structure (some HTML5 elements that are not yet
+		 * implemented in IE for example). Some effort was made to fix a
+		 * broken DOM structure, if it is encountered. There is one case
+		 * which results in an unrecoverably broken DOM structure, which
+		 * is an unrecognized element not preceded by some text. See the
+		 * tests for further information.
+		 *
+		 * IE8 bug: whitespace is not reliably preserved when the style
+		 * white-space:pre (or similar) is used. See the tests for
+		 * further information. Whitespace inside <pre> elements will
+		 * be preserved, but \n characters will become \r characters.
+		 *
+		 * IE7 bug: URLs in href and src attributes of a and img
+		 * elements will be absolutized (including hostname and
+		 * protocol) if they are given as a relative path.
+		 *
+		 * IE bug: Namespace support inside contentEditable=true is a
+		 * bit shaky on IE. Don't use it if possible. See the tests to
+		 * get an idea of what seems to work. Make namespace prefixes
+		 * and element names all lower-case, as they are always
+		 * lower-cased, even if the element doesn't occur in an HTML
+		 * namespace. Don't use default namespaces, use prefixes (except
+		 * for an HTML namespace).
+		 *
+		 * @param node
+		 *        A DOM node to serialize
+		 * @return
+		 *        The serialized XHTML string represnting the given DOM node.
+		 */
+		nodeToXhtml: function(node) {
+			var xhtml = [];
+			serialize(node, xhtml);
+			return xhtml.join("");
+		}
+	};
+});

--- a/src/test/index.html
+++ b/src/test/index.html
@@ -41,6 +41,10 @@
 		<li><a href="unit/indent.html">Indent</a></li>
 		<li><a href="unit/outdent.html">Outdent</a></li>
 	</ul>
+	<h2>Common Plugins</h2>
+	<ul>
+	  <li><a href="unit/plugins/dom-to-xhtml-tests.html">dom-to-xhtml</a></li>
+	</ul>
 	</div>
 	<div id="footer">
 		<p>Report an <a href="https://github.com/alohaeditor/Aloha-Editor/issues">issue on github</a> &middot; <a href="http://aloha-editor.org">http://aloha-editor.org</a>

--- a/src/test/unit/plugins/dom-to-xhtml-tests.html
+++ b/src/test/unit/plugins/dom-to-xhtml-tests.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>Aloha Editor dom-to-xhtml Plugin Test Suite</title>
+	
+	<!-- include qunit -->
+	<link rel="stylesheet" href="../../vendor/qunit.css" type="text/css"/>
+	<script type="text/javascript" src="../../vendor/qunit.js"></script>
+	<script	src="../../vendor/jquery-1.6.1.js" ></script>
+
+	<!-- include aloha and the dom-to-xhtml plugin which we are about to test -->
+	<script>
+		var Aloha = { jQuery: $ };
+	</script>
+	<script src="../../../lib/aloha.js" data-aloha-plugins="common/dom-to-xhtml"></script>
+	
+	<!-- include testswarm inject script -->
+	<script>
+		var url = window.location.search;
+		url = decodeURIComponent( url.slice( url.indexOf("swarmURL=") + 9 ) );
+		if ( url && url.indexOf("http") === 0 ) {
+			require(["http://testswarm.aloha-editor.org/js/inject.js?" + (new Date).getTime()], function() {});
+		}
+	</script>
+
+</head>
+<body>
+	<!-- include the tests -->
+	<script>
+		require( ['dom-to-xhtml-tests'] );
+	</script>
+	<h1 id="qunit-header">Aloha Editor dom-to-xhtml Plugin Test Suite</h1>
+	<h2 id="qunit-banner"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<h2 id="qunit-userAgent"></h2>
+	<ol id="qunit-tests"></ol>
+	<div id="qunit-fixture">
+	<div id="test-editable"></div>
+	</div>
+</body>
+</html>

--- a/src/test/unit/plugins/dom-to-xhtml-tests.js
+++ b/src/test/unit/plugins/dom-to-xhtml-tests.js
@@ -1,0 +1,280 @@
+/*!
+ * This file is part of Aloha Editor
+ * Author & Copyright (c) 2010 Gentics Software GmbH, aloha@gentics.com
+ * Licensed unter the terms of http://www.aloha-editor.com/license.html
+ */
+
+define(
+	[],
+function() {
+	"use strict";
+
+	/**
+	 * Initializes an Aloha editable with the given HTML and passes it to the given callback function.
+	 *
+	 * @param func
+	 *        A callback function that is invoked with an instance of Aloha.Editable as the first argument.
+	 * @param editableHtml
+	 *        Optionally the HTML to put into the editable before calling $.aloha() on it.
+	 *        May be null if the editable should be left as is.
+	 * @param id
+	 *        Optionally the id of the editable. By default a div with id 'test-editable' will be used.
+	 */
+	function withEditable(func, editableHtml, id) {
+		id = id || 'test-editable';
+		var editable = jQuery("#" + id);
+		if (null != editableHtml) {
+			editable.html(editableHtml);
+		}
+		editable.aloha();
+		var alohaEditable = Aloha.getEditableById(id)
+		func(alohaEditable);
+		alohaEditable.destroy();
+	}
+
+	/**
+	 * Tests whether a DOM is serialized correctly.
+	 *
+	 * Tests the Aloha.Editable.getContents() instance method which is
+	 * used to serialize the content of an editable. The dom-to-xhtml
+	 * plugin sets a special XHTML content serializer which replaces the
+	 * default $.html() serializer used by getContents().
+	 *
+	 * @param editableHtml
+	 *        The HTML to put into the editable before calling getContents().
+	 * @param expectedXhtml
+	 *        The XHTML expected to be returned by Aloha.Editable.getContents().
+	 *        This may be an array of strings, if the result may be one of multiple
+	 *        possible values. If an array is passed, at least one of the values in the
+	 *        array has to match the resulting XHTML to pass the test. This is useful
+	 *        if the expected result may differ between browsers.
+	 */
+	function testGc(editableHtml, expectedXhtml) {
+		withEditable(function(editable){
+			var contents = editable.getContents();
+			if (jQuery.isArray(expectedXhtml)) {
+				var foundEqual = false;
+				for (var i = 0; i < expectedXhtml.length; i++) {
+					if (contents == expectedXhtml[i]) {
+						foundEqual = true;
+						break;
+					}
+				}
+				if ( ! foundEqual ) {
+					equal(contents, expectedXhtml[0]);
+				} else {
+					ok(true);
+				}
+			} else {
+				equal(contents, expectedXhtml);
+			}
+		}, editableHtml);
+	}
+
+	/**
+	 * Tests whether dynamically set styles are serialized correctly.
+	 *
+	 * @param styleMap
+	 *        A map of styles to set dynamically. Values in the map
+	 *        may be arrays, in which case the first value in the array will be used
+	 *        to set the style dynamically, and the rest of the values represent
+	 *        alternative results at least one of which must match the reparsed
+	 *        style to pass the test.
+	 * @param elementHtml
+	 *        A HTML string representing an element to set the given styles on.
+	 */
+	function testStyle(styleMap, elementHtml) {
+		withEditable(function(editable){
+			var element = editable.obj.children().eq(0);
+			var jqStyleMap = {};
+			for (var style in styleMap) {
+				if (styleMap.hasOwnProperty(style)) {
+					var styleValue = styleMap[style];
+					jqStyleMap[style] = $.isArray(styleValue) ? styleValue[0] : styleValue;
+				}
+			}
+			element.css(jqStyleMap);
+			var contents = editable.getContents();
+			// After parsing the serialized XHTML, the styles that were
+			// dynamically set should be still be there. If not, they were
+			// lost during serialization.
+			var reparsedElement = $(contents).eq(0);
+			for (var style in styleMap) {
+				if (styleMap.hasOwnProperty(style)) {
+					var reparsedStyleValue = reparsedElement.css(style);
+					var styleValue = styleMap[style];
+					if ($.isArray(styleValue)) {
+						var found = false;
+						for (var i = 0; i < styleValue.length; i++) {
+							if (reparsedStyleValue == styleValue[i]) {
+								found = true;
+							}
+						}
+						if ( ! found ) {
+							equal(reparsedStyleValue, styleValue[0]);
+						} else {
+							ok(true);
+						}
+					} else {
+						equal(reparsedStyleValue, styleValue);
+					}
+				}
+			}
+		}, elementHtml);
+	}
+
+	Aloha.ready( function() {
+		module('Serialization');
+
+		test('links', function() {
+			testGc('<a href="http://www.example.com">link</a>',
+				   ['<a href="http://www.example.com">link</a>',
+					// IE7 adds a trailing slash to the href
+					'<a href="http://www.example.com/">link</a>'
+				   ]);
+			testGc('<a href="http://www.example.com/?#anchor">link</a>', '<a href="http://www.example.com/?#anchor">link</a>');
+			// TODO: IE7 fails because it makes a fully qualified URL out of the links. This issue
+			// is documented for the nodeToXhtml() method.
+			//testGc('<a href="relative/link">link</a>', '<a href="relative/link">link</a>');
+			//testGc('<a href="/absolute/link">link</a>', '<a href="/absolute/link">link</a>');
+		});
+		test('empty elements without closing tag', function() {
+			testGc('some <br>text', 'some <br/>text');
+			testGc('some<img src="http://www.example.com/img.jpg">text', 'some<img src="http://www.example.com/img.jpg"/>text');
+		});
+		test('tables', function() {
+			testGc('<table><tr><th>one<th>two<tr><td>three<td>four</table>', [
+				'<table><tbody><tr><th>one</th><th>two</th></tr><tr><td>three</td><td>four</td></tr></tbody></table>',
+				// IE adds spaces after text in each cell except the last one
+				'<table><tbody><tr><th>one </th><th>two </th></tr><tr><td>three </td><td>four</td></tr></tbody></table>'
+			]);
+		});
+		test('lists', function() {
+			testGc('<ul><li><ol><li>one<li>two</ol></ul>', [
+				'<ul><li><ol><li>one</li><li>two</li></ol></li></ul>',
+				// IE adds a space after the text in the first list item
+				'<ul><li><ol><li>one </li><li>two</li></ol></li></ul>'
+			]);
+		});
+		test('empty elements with closing tag', function() {
+			testGc('some<span></span>text', 'some<span></span>text');
+			testGc('some<div></div>text', [
+				'some<div></div>text',
+				// IE adds a space before a div (IE8)
+				'some <div></div>text'
+			]);
+		});
+		test('boolean attributes', function() {
+			testGc('<input type="checkbox" checked>', [
+				'<input type="checkbox" checked="checked"/>',
+				// IE7 adds size="20" which we can't strip since we can't know
+				// whether it's just a default or a real attribute.
+			    '<input type="checkbox" size="20" checked="checked"/>']);
+		});
+		test('"pre" preserves spaces tabs and newlines', function() {
+			var pre = "<pre>\n"
+				+ "		two leading tabs\n"
+				+ "        leading whitespace\n"
+				+ "</pre>";
+			withEditable(function(editable) {
+				// On IE8, \n characters become \r characters
+				equal(editable.getContents().replace(/\n/g, '\r'),
+					   // The newline after the opening pre tag is lost (Chrome).
+					   // This is the same behaviour as with element.innerHTML (Chrome).
+					  ("<pre>		two leading tabs\n"
+					   + "        leading whitespace\n"
+					   + "</pre>").replace(/\n/g, '\r'));
+			}, pre);
+			var whiteSpacePre
+				= '<span style="white-space: pre">\n'
+				+ "		two leading tabs\n"
+				+ "        leading whitespace\n"
+				+ "</span>";
+			withEditable(function(editable) {
+				// Serializing a span with "white-space: pre" style on IE8 is unpredictable:
+				// the whitespace will most of the time not be preserved, but it sometimes will (loading
+				// the same page multiple times yields different results).
+				// TODO: This test is disabled. The issue is documented for the nodeToXhtml() method.
+				//equal(editable.getContents().replace(/\s/g, ' . '), whiteSpacePre.replace(/\s/g, ' . '));
+			}, whiteSpacePre);
+		});
+		test('special characters in attributes', function() {
+			testGc('<img src="http://www.example.com/?one=two&three&&amp;four">',
+				   '<img src="http://www.example.com/?one=two&amp;three&amp;&amp;four"/>');
+			testGc('<img alt="left << middle >> right">',
+				   '<img alt="left &lt;&lt; middle >> right"/>');
+			testGc("<img alt='some \"quoted\" text'>",
+				   '<img alt="some &quot;quoted&quot; text"/>');
+		});
+		test('special characters in intra-element text', function() {
+			testGc('<span>big < bigger < biggest</span>', '<span>big &lt; bigger &lt; biggest</span>');
+			testGc('<span>You&Me&You</span>', '<span>You&amp;Me&amp;You</span>');
+		});
+		test('script tags', function() {
+			// Script tags are not preserved (Chrome).
+			// This is the same behaviour as with element.innerHTML (Chrome).
+			testGc('<div>pre-script<script> if (1 < 2 && true) { } else { } </script>post-script</div>',
+				   '<div>pre-scriptpost-script</div>');
+		});
+		test('IE conditional includes', function() {
+			var conditionalInclude = '<div><!--[if IE 8 ]> <span> some text </span> <![endif]--></div>';
+			// IE8 doesn't report conditional comments in contentEditable=true
+			// TODO: This test is disabled. The issue is documented for the nodeToXhtml() method.
+			//testGc(conditionalInclude, conditionalInclude);
+		});
+		test('normal comments', function() {
+			// IE8 doesn't always report comments inside
+			// contentEditable=true correctly. In this example the 'x'
+			// before the comment is necessary, otherwise the comment
+			// will not appear in the DOM.
+			var comment = '<span>x<!-- some comment --></span>';
+			testGc(comment, comment);
+		});
+		test('serializing dynamically set css attributes', function() {
+			testStyle({
+				// some random css properties
+				'color': [ 'green', 'rgb(0, 128, 0)' ],
+				'width': '5px'
+			}, '<div></div>');
+		});
+		test('namespaced XML', function() {
+			var namespacedXml
+				= '<div xmlns:books="urn:loc.gov:books">'
+				+ '<books:book xmlns:isbn="urn:ISBN:0-395-36341-6">'
+				+ '<isbn:number>1568491379</isbn:number>'
+				+ '<books:notes>'
+			    // IE8 inserts a space before the p if it's not already there
+				+ ' <p xmlns="http://www.w3.org/1999/xhtml">'
+				+ 'This is also available <a href="http://www.w3.org/">online</a>.'
+				+ '</p>'
+				+ '</books:notes>'
+				+ '</books:book>'
+				+ '</div>';
+			testGc(namespacedXml, namespacedXml);
+		});
+		test('IE unrecognized XML', function() {
+			// The x at the beginning is required. If there is some text
+			// before unrecognized elements, the DOM structure will
+			// incorrect but still predictable. If there is no text
+			// before unrecognized elements, the DOM structure will
+			// become unpredictable in a way we can't compensate for.
+			var unrecognizedXml
+				= 'x<ie-unrecognized-1 some-attr="some-value">'
+				+ '<ie-unrecognized-2>'
+				+ '<ie-unrecognized-3>'
+				+ '<span>some text</span>'
+				+ '</ie-unrecognized-3>'
+				+ '<ie-unrecognized-4>'
+				+ 'more text'
+				+ ' <span>even more text</span>'
+				+ '<!-- comment -->'
+				+ '</ie-unrecognized-4>'
+				+ '</ie-unrecognized-2>'
+				+ '<ie-unrecognized-5>'
+				+ '<span> one more text</span>'
+				+ '</ie-unrecognized-5>'
+				+ '</ie-unrecognized-1>';
+			testGc(unrecognizedXml, unrecognizedXml);
+		});
+	});
+});


### PR DESCRIPTION
The plugin required extension of editable.js so that it is able to
install its own serializer.
