### PR TITLE
Fixes a bug that caused only a single root node to be displayed

### DIFF
--- a/build/release-changelog.md
+++ b/build/release-changelog.md
@@ -1,1 +1,2 @@
 - **BUG** table-plugin: fixed a javascript error when the block plugin wasn't loaded.
+- **BUG** browser-plugin: fixed a bug that caused only a single root-node to be displayed.

--- a/src/plugins/extra/browser/lib/browser.js
+++ b/src/plugins/extra/browser/lib/browser.js
@@ -527,12 +527,9 @@ var Browser = Class.extend({
 						repositoryId : obj.repositoryId
 					},
 					function (data) { 
-						if (obj.loaded === false) {// should not be called twice
-							obj.loaded = true;
-							
-							if (typeof callback === 'function') {
-								callback(data);
-							}
+						obj.loaded = true;
+						if (typeof callback === 'function') {
+							callback(data);
 						}
 					}
 				);


### PR DESCRIPTION
The if statement was supposed to be part of a fix for duplicate browser entries in commit
508d7a6c0278210d56aa2322d0bc09d75223e7de

The if statement caused only a single root node to be displayed with the
GCN repository. I was unable to reproduce the bug with duplicate browser
entries after removing the if, so maybe it was optional?
