### PR TITLE
core: Fixed a permission error in Firefox, when Aloha Editor tried to access a document property of an external ressource

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -1,0 +1,1 @@
+- **BUG** core: Fixed a permission error in Firefox, when Aloha Editor tried to access a document property of an external ressource

--- a/src/lib/aloha/selection.js
+++ b/src/lib/aloha/selection.js
@@ -352,8 +352,18 @@ function(Aloha, jQuery, FloatingMenu, Class, Range) {
 					// the start of the selection was not yet found, so look for it now
 					// check whether the start of the selection is found here
 
+					// Try to read the nodeType property and return if we do not have permission
+					// ie.: frame document to an external URL
+					var nodeType;
+					try {
+						nodeType = this.nodeType;
+					}
+					catch (e) {
+						return;
+					}
+
 					// check is dependent on the node type
-					switch(this.nodeType) {
+					switch(nodeType) {
 					case 3: // text node
 						if (this === rangeObject.startContainer) {
 							// the selection starts here

--- a/src/lib/util/dom.js
+++ b/src/lib/util/dom.js
@@ -669,8 +669,19 @@ var Dom = Class.extend({
 
 		// iterate through all sub nodes
 		startObject.contents().each(function(index) {
+
+			// Try to read the nodeType property and return if we do not have permission
+			// ie.: frame document to an external URL
+			var nodeType;
+			try {
+				nodeType = this.nodeType;
+			}
+			catch (e) {
+				return;
+			}
+
 			// decide further actions by node type
-			switch(this.nodeType) {
+			switch(nodeType) {
 			// found a non-text node
 			case 1:
 				if (prevNode && prevNode.nodeName == this.nodeName) {


### PR DESCRIPTION
[DONE] obey coding guidelines http://aloha-editor.org/builds/development/latest/doc/guides/output/style_guide.html
[N/A] write JSLint compliant code
[N/A] write JSDoc for every method you touched during your implementation
[DONE] write a human-readable :) [[changelog]] entry that describes your change
[N/A] add a qunit test (if it makes sense) and/or document the steps to manually test it (in a separate guides page)
[DONE] test your changes in Internet Explorer 7, 8, 9 and the latest Firefox and latest Chrome
[N/A] document your changes in a guide
[DONE] include this list in a your pull request
