### PR TITLE
table-plugin: Fixed the cleanup of the table cells on blur not cleaning up correctly (caused by a typo in the element class)

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -2,3 +2,4 @@
 **ENHANCEMENT**: updated integration of Aloha Blocks to the most recent version
 *BUG* floatingmenu: Fixed problem with showing floatingmenu shadow too early
 **BUG** core: Fixed a permission error in Firefox, when Aloha Editor tried to access a document property of an external ressource
+**BUG** table-plugin: Fixed the cleanup of the table cells on blur not cleaning up correctly (caused by a typo in the element class)

--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -201,7 +201,7 @@ function (jQuery, Utils) {
 		this.hasFocus = false;
 
 		// remove "active class"
-		this.obj.removeClass('aloha-table-cell-active');
+		this.obj.removeClass('aloha-table-cell_active');
 	};
 
 	/**


### PR DESCRIPTION
[DONE] obey coding guidelines http://aloha-editor.org/builds/development/latest/doc/guides/output/style_guide.html
[N/A] write JSLint compliant code
[N/A] write JSDoc for every method you touched during your implementation
[DONE] write a human-readable :) [[changelog]] entry that describes your change
[N/A] add a qunit test (if it makes sense) and/or document the steps to manually test it (in a separate guides page)
[DONE] test your changes in Internet Explorer 7, 8, 9 and the latest Firefox and latest Chrome
[N/A] document your changes in a guide
[DONE] include this list in a your pull request
