### PR TITLE
HotfixRemoved unwanted behaviour from the block plugin's sidebarattributeedtior, which will clear out the whole sidebar when loaded

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -8,3 +8,5 @@ All changes are categorized into one of the following keywords:
 
 ----
 
+**ENHANCEMENT**: Removed unwanted behaviour from the block plugin's sidebarattributeedtior, which will clear out the whole sidebar when loaded
+

--- a/src/plugins/common/block/lib/sidebarattributeeditor.js
+++ b/src/plugins/common/block/lib/sidebarattributeeditor.js
@@ -42,8 +42,8 @@ define([ 'aloha/jquery', 'block/blockmanager', 'aloha/sidebar', 'block/editorman
 			}
 			// TODO: Clearing the whole sidebar might not be what we want; instead we might only want
 			// to clear certain panels.
-			that._sidebar.container.find('.aloha-sidebar-panels').children().remove();
-			that._sidebar.panels = {};
+			// that._sidebar.container.find('.aloha-sidebar-panels').children().remove();
+			// that._sidebar.panels = {};
 
 			jQuery.each(selectedBlocks, function() {
 				var schema = this.getSchema(),
@@ -96,7 +96,8 @@ define([ 'aloha/jquery', 'block/blockmanager', 'aloha/sidebar', 'block/editorman
 
 						// This code is from the superclass
 						this.isActive = false;
-						this.content.parent('li').hide();
+						// TODO check if this is needed in current block implementation
+						// this.content.parent('li').hide();
 						this.effectiveElement = null;
 					}
 				});


### PR DESCRIPTION
http://aloha-editor.org/builds/development/latest/doc/guides/output/style_guide.html
DONE write JSLint compliant code
DONE write JSDoc for every method you touched during your implementation
DONE write a human-readable :) changelog entry that describes your change
N/A add a qunit test (if it makes sense) and/or document the steps to manually
test it (in a separate guides page)
DONE test your changes in Internet Explorer 7, 8, 9 and the latest Firefox and
latest Chrome
N/A document your changes in a guide
DONE include this list in a your pull request
