### PR TITLE
Comment including "{" character causes error in testutils.js

### DIFF
--- a/src/test/unit/testutils.js
+++ b/src/test/unit/testutils.js
@@ -388,7 +388,6 @@ define(	[ '../../lib/aloha/ecma5shims' ], function($_) {
 		
 		addBrackets: function (range) {
 			var marker;
-			//@{
 			// Handle the collapsed case specially, to avoid confusingly getting the
 			// markers backwards in some cases
 			if (range.endContainer.nodeType == $_.Node.TEXT_NODE


### PR DESCRIPTION
//@{ 

is actually parsed by some versions of IE9 and IE8 in our pages, resulting in the following error:  

SCRIPT1009: Expected '}' 
testutils.js, line XXX character 2

It is as though IE parses the "{" character of the comment as the beginning of a script block, and then complains that it isn't closed.

Removing this comment fixes the bug for us.  Please consider eliminating the "{" character from future comments.
