### PR TITLE
Only check attr.specified if it is defined.

### DIFF
--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -1421,12 +1421,17 @@ function movePreservingRanges(node, newParent, newIndex, range) {
  * @return void
  */
 function copyAttributes( element,  newElement ) {
-	for ( var i = 0; i < element.attributes.length; i++ ) {
-		if ( typeof newElement.setAttributeNS === 'function' ) {
-			newElement.setAttributeNS( element.attributes[i].namespaceURI, element.attributes[i].name, element.attributes[i].value );
-		} else if ( element.attributes[i].specified ) {
-			// fixes https://github.com/alohaeditor/Aloha-Editor/issues/515 
-			newElement.setAttribute( element.attributes[i].name, element.attributes[i].value );
+	var attrs = element.attributes;
+	for ( var i = 0; i < attrs.length; i++ ) {
+		var attr = attrs[i];
+		// attr.specified is an IE specific check to exclude attributes that were never really set.
+		if (typeof attr.specified == "undefined" || attr.specified) {
+			if ( typeof newElement.setAttributeNS === 'function' ) {
+				newElement.setAttributeNS( attr.namespaceURI, attr.name, attr.value );
+			} else {
+				// fixes https://github.com/alohaeditor/Aloha-Editor/issues/515 
+				newElement.setAttribute( attr.name, attr.value );
+			}
 		}
 	}
 }


### PR DESCRIPTION
If a browser didn't support either setAttributeNS or attr.specified
no attributes would have been copied.
Only IE supports attr.specified as far as I know.

obey coding guidelines http://aloha-editor.org/builds/development/latest/doc/guides/output/style_guide.html
DONE

write JSLint compliant code
Depends on the JSLint settings I suppose

write JSDoc for every method you touched during your implementation
OK

write a human-readable :) changelog entry that describes your change
Not applicable since there is no known change in functionality. This fix is for a pull request that was merged a couple of days ago.

add a qunit test (if it makes sense) and/or document the steps to manually test it (in a separate guides page)
Don't want to.

test your changes in Internet Explorer 7, 8, 9 and the latest Firefox and latest Chrome
IE7 crashes, but not because of this change. Works in IE8. Also tested in Chrome. I suppose that's enough.

document your changes in a guide
Not applicable.

include this list in a your pull request
DONE
