### PR TITLE
Fixed issue #594 - Incorrect usage of jQuery global reference

### DIFF
--- a/src/plugins/common/ui/lib/arena.js
+++ b/src/plugins/common/ui/lib/arena.js
@@ -1,4 +1,4 @@
-define(['ui/component'],function(Component){
+define(['jquery', 'ui/component'],function($, Component){
 	var Arena = Component.extend({
 		init: function(){
 			this.element = $('<div>');

--- a/src/plugins/common/ui/lib/utils.js
+++ b/src/plugins/common/ui/lib/utils.js
@@ -1,4 +1,4 @@
-define(['jqueryui'], function() {
+define(['jquery', 'jqueryui'], function($) {
 	'use strict';
 	var Utils = {
 		makeButton: function(button, props, hasMenu) {


### PR DESCRIPTION
This is a trivial bugfix to fix a problem with multiple versions of jQuery and jQuery UI being used on a page and by Aloha.
