### PR TITLE
Modified baseUrl lookup to allow url parameters

### DIFF
--- a/src/lib/aloha.js
+++ b/src/lib/aloha.js
@@ -50,7 +50,7 @@
 		    plugins = Aloha.settings.plugins && Aloha.settings.plugins.load,
 		    baseUrl = Aloha.settings.baseUrl,
 		    pluginsAttr,
-		    regexAlohaJs = /\/aloha\.js$/,
+		    regexAlohaJs = /\/aloha.js(\?\S*)?$/,
             regexStripFilename = /\/[^\/]*\.js$/,
 		    i;
 


### PR DESCRIPTION
Some frameworks etc (in this case FuelPHP) append
parameters to the url of script tags for caching purposes.

I modified the regEx to allow it to match:
- /js/aloha/lib/aloha.js?anything
- /js/aloha/lib/aloha.js?343432
- /js/aloha/lib/aloha.js?
- /js/aloha/lib/aloha.js
