### PR TITLE
Add 'block-activate' and 'block-deactivate' events for blocks.

### DIFF
--- a/src/plugins/common/block/lib/block.js
+++ b/src/plugins/common/block/lib/block.js
@@ -422,7 +422,9 @@ define([
 					Aloha.Selection.updateSelection(event);
 				}
 			}
-			// Trigger selection change event
+
+			// Trigger block activate & selection change events.
+			BlockManager.trigger('block-activate', highlightedBlocks);
 			BlockManager.trigger('block-selection-change', highlightedBlocks);
 		},
 
@@ -431,12 +433,17 @@ define([
 		 */
 		deactivate: function() {
 			var that = this;
+			var deactivatedBlocks = [this];
 			this._unhighlight();
 			this.$element.parents('.aloha-block').each(function() {
+				deactivatedBlocks.push(this);
 				that._unhighlight();
 			});
 
 			this.$element.removeClass('aloha-block-active');
+
+			// Trigger block deactivate & selection change events.
+			BlockManager.trigger('block-deactivate', deactivatedBlocks);
 			BlockManager.trigger('block-selection-change', []);
 		},
 


### PR DESCRIPTION
The `block-selection-change` is cumbersome to rely on when you don't care about the _global_ state of "which blocks are selected?" but when you do care about the _local_ state of each block, i.e. when you want to do things whenever a block gets focus or loses focus.

Hence the addition of these two events to `block.js`.
