### PR TITLE
Update src/lib/vendor/jquery-1.7.2.js

### DIFF
--- a/src/lib/vendor/jquery-1.7.2.js
+++ b/src/lib/vendor/jquery-1.7.2.js
@@ -9387,8 +9387,6 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 
 
 
-// Expose jQuery to the global object
-window.jQuery = window.$ = jQuery;
 
 // Expose jQuery as an AMD module, but only for AMD loaders that
 // understand the issues with loading multiple versions of jQuery
@@ -9404,6 +9402,10 @@ window.jQuery = window.$ = jQuery;
 // noConflict to hide this version of jQuery, it will work.
 if ( typeof define === "function" && define.amd && define.amd.jQuery ) {
 	define( "jquery", [], function () { return jQuery; } );
+}
+else {
+	// Expose jQuery to the global object
+	window.jQuery = window.$ = jQuery;
 }
 
 // ===================== PATCHES =====================


### PR DESCRIPTION
Rather than assign jQuery to the global object in all cases, assign the scoped jQuery variable to window.jQuery only if the define function is undefined. This will prevent Aloha from mashing jQuery already on the page.
