### PR TITLE
Captioned Image breaks when no data-align attribute is set

### DIFF
--- a/src/plugins/extra/captioned-image/lib/captioned-image-plugin.js
+++ b/src/plugins/extra/captioned-image/lib/captioned-image-plugin.js
@@ -331,9 +331,11 @@ define([
 			// Whenever we need to use other attributes, we'll have to retrieve
 			// it from the original image.
 			var caption = $img.attr('data-caption');
+			var align = $img.attr('data-align');
 			caption = (typeof caption !== 'undefined') ? caption : '';
+			align = (typeof align !== 'undefined') ? align : false;
 			$block.attr('data-caption',        caption)
-			      .attr('data-align',          $img.attr('data-align'))
+			      .attr('data-align',          align)
 			      .attr('data-width',          getImageWidth($img))
 			      .attr('data-original-image', $img[0].outerHTML);
 		}


### PR DESCRIPTION
I think this only happens when using jQuery 1.7.1, which is the version Drupal is using. Because it used to work.

This change makes the code more robust anyway, so it should be good to go :)
