### PR TITLE
Fix for jqueryui and the <base /> tag.

### DIFF
--- a/src/plugins/common/ui/lib/tab.js
+++ b/src/plugins/common/ui/lib/tab.js
@@ -74,7 +74,7 @@ define([
 			this.panels = this.container.data('panels');
 			this.id = 'tab-ui-container-' + (++idCounter);
 			this.panel = $('<div>', {id : this.id, 'unselectable': 'on'});
-			this.handle = $('<li><a href="#' + this.id + '">' +
+			this.handle = $('<li><a href="' + location.href.replace(/#.*$/) + '#' + this.id + '">' +
 				settings.label + '</a></li>');
 
 			for (i = 0; i < components.length; i++) {


### PR DESCRIPTION
Use the current page in the tab anchors, otherwise thereby making the link
explicitly local, so that a <base /> tag does not accidentally make it a remote
link.
#633
