### PR TITLE
Make Repository API lookups work again for the Image plug-in's imageSource

### DIFF
--- a/src/plugins/common/image/lib/image-floatingMenu.js
+++ b/src/plugins/common/image/lib/image-floatingMenu.js
@@ -141,6 +141,7 @@ function (
 				name: 'imageSource',
 				scope: plugin.name
 			});
+			this.imgSrcField.setTemplate( '<span><b>{name}</b><br/>{url}</span>' );
 			this.imgSrcField.setObjectTypeFilter(plugin.objectTypeFilter);
 			
 			this.imgTitleField = AttributeField({


### PR DESCRIPTION
This is the minimally viable fix. It'd be nicer if we could conditionally, on a per-result basis, show a thumbnail. But I'm not sure if that is supported. That can be a follow-up issue anyway.
