### PR TITLE
Allow Aloha.settings.plugins.image.objectFilterType to define the type o...

### DIFF
--- a/src/plugins/common/image/lib/image-plugin.js
+++ b/src/plugins/common/image/lib/image-plugin.js
@@ -246,6 +246,9 @@ define([
 		 */
 		restoreProps: [],
 
+		/**
+		 * the defined object types to be used for this instance
+		 */
 		objectTypeFilter: [],
 
 		/**
@@ -257,7 +260,9 @@ define([
 			
 			var imagePluginUrl = Aloha.getPluginUrl('image');
 			
-			
+			if ( typeof this.settings.objectTypeFilter != 'undefined' ) {
+				this.objectTypeFilter = this.settings.objectTypeFilter;
+			}
 			
 			// Extend the default settings with the custom ones (done by default)
 			plugin.startAspectRatio = plugin.settings.fixedAspectRatio; 


### PR DESCRIPTION
...f repository items to be searched when typing keywords in the imageSource attribute field.

The code is identical to that of the link plug-in.

Complements #757.
