### PR TITLE
Change Aloha-table arrows for ie7 - set arrow-default for the css

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -42,3 +42,5 @@ All changes are categorized into one of the following keywords:
 		   nested inside blocks. Before this fix, when pressing CTRL-C to copy
 		   the current selection in an editable nested inside a block, the whole
 		   block was selected and copied.
+- **BUG**: table-plugin: Fixed the cursor problem with ie7. Now ie7 shows the 
+           system default arrows.

--- a/src/plugins/common/table/css/table.css
+++ b/src/plugins/common/table/css/table.css
@@ -60,11 +60,10 @@ td.aloha-table-selectrow {
 	cursor: text !important;
 }
 .aloha-table tr.aloha-table-selectcolumn td {
-	cursor: url(../img/down.cur),default;
+	cursor: url(../img/down.cur),s-resize;
 }
-/* :tODO: make custom cursors visible in IE */
 .aloha-table td.aloha-table-selectrow {
-	cursor: url(../img/left.cur),default;
+	cursor: url(../img/left.cur),e-resize;
 }
 
 /* wai indicator */


### PR DESCRIPTION
- [n/a] obey coding guidelines
- [n/a] write JSLint compliant code
- [n/a] write JSDoc for every method you touched during your implementation
- [done] write a human-readable :) Changelog entry that describes your change
- [n/a] add a qunit test (if it makes sense) and/or document the steps to manually test it (in a separate guides page)
- [done] test your changes in Internet Explorer 7, 8, 9 and the latest Firefox and latest Chrome
- [n/a] document your changes in a guides page
- [done] include this list in a your pull request
