### PR TITLE
Fix for 'We need to be more intelligent about whether we insert a block-...

### DIFF
--- a/src/lib/aloha/markup.js
+++ b/src/lib/aloha/markup.js
@@ -194,8 +194,6 @@ define([
 	}
 
 	/**
-	 * @TODO(petro): We need to be more intelligent about whether we insert a
-	 *               block-level placeholder or a phrasing level element.
 	 * @TODO(petro): test with <pre>
 	 * @TODO: move to block-jump.js
 	 */
@@ -205,6 +203,12 @@ define([
 
 		if (!sibling || isBlock(sibling)) {
 			var $landing = jQuery('<div>&nbsp;</div>');
+			if (sibling) {
+				$landing.css('display', jQuery(sibling).css('display'));
+				if ("inline" === jQuery(sibling).css('display')) {
+					$landing.html("&#8203;");
+				}
+			}
 
 			if (isGoingLeft) {
 				jQuery(block).before($landing);


### PR DESCRIPTION
...level placeholder or a phrasing level element.'

When using the arrow keys to navigate between adjacent Aloha blocks with "display:inline", the inserted <div> causes an unexpected newline to appear until the block is deactivated.
