### PR TITLE
Remove cursor-styles in table after editing

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -8,3 +8,5 @@ All changes are categorized into one of the following keywords:
 
 ----
 
+**BUGFIX**: Cursor styles that are added inside tables for resizing are now
+            correctly removed when the table is no longer editable.

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -1532,6 +1532,10 @@ define([
 		// remove the "selection class" from all td and th in the table
 		this.obj.find('td, th').removeClass(this.get('classCellSelected'));
 		this.obj.find('td, th').removeClass('aloha-table-cell_active');
+
+		// remove cursor-styles
+		this.obj.find('td, th').css('cursor', '');
+
 		this.obj.unbind();
 		this.obj.children('tbody').unbind();
 


### PR DESCRIPTION
when resizing tables, cursor styles are used to drag fields. these should be removed after editing, otherwise they remain in the saved page.

please review and integrate :)
