### PR TITLE
naturalfit button resets width on th elements

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -13,3 +13,6 @@ All changes are categorized into one of the following keywords:
 - **BUGFIX**: Headerids plugin no longer changes ids of Aloha Editables, which
 			  was causing implementations to loose track of editables during
 			  saving of example.
+- **BUGFIX**: naturalfit-button (reset) in table resize plugin did not remove
+			  width from table head (th) elements
+

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -613,7 +613,7 @@ define([
 				click: function() {
 					if (that.activeTable) {
 						var tableObj = that.activeTable.obj;
-						tableObj.find('td').each(function() {
+						tableObj.find('td, th').each(function() {
 							jQuery(this).find('div').css('width', '');
 							jQuery(this).css('width', '');
 						});


### PR DESCRIPTION
naturalfit button in table resize plugin did not reset the element style width on table head elements
