### PR TITLE
Added missing german translations for table plugin

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -8,3 +8,5 @@ All changes are categorized into one of the following keywords:
 
 ----
 
+- **ENHANCEMENT**: Added missing german translations for table plugin components
+

--- a/src/plugins/common/align/nls/de/i18n.js
+++ b/src/plugins/common/align/nls/de/i18n.js
@@ -2,5 +2,8 @@ define({
 	"button.alignright.tooltip": "Rechtsbünding",
 	"button.alignleft.tooltip": "Linksbündig",
 	"button.aligncenter.tooltip": "Zentriert",
-	"button.alignjustify.tooltip": "Blocksatz"
+	"button.alignjustify.tooltip": "Blocksatz",
+	"button.aligntop.tooltip": "Oben aurichten",
+	"button.alignmiddle.tooltip": "Zentriert ausrichten",
+	"button.alignbottom.tooltip": "Unten ausrichten"
 });

--- a/src/plugins/common/ui/nls/de/i18n.js
+++ b/src/plugins/common/ui/nls/de/i18n.js
@@ -43,5 +43,6 @@ define({
 	"tab.table.label": "Tabelle",
 	"tab.col.label": "Tabellenspalte",
 	"tab.row.label": "Tabellenzeile",
+	"tab.cell.label": "Tabellenzelle",
 	"tab.wai-lang.label": "Sprachauszeichnung"
 });


### PR DESCRIPTION
Some german translations were missing in the table plugin
- for the table cell tab
- for the vertical align button tooltips in the table cell tab
