### PR TITLE
Fix inserting linebreaks in editable spans

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -8,5 +8,8 @@ All changes are categorized into one of the following keywords:
 
 ----
 
-**BUGFIX**: Previously selected blocks are no longer deleted when hitting
-            backspace from inside an Aloha Editor UI.
+- **BUGFIX**: Previously selected blocks are no longer deleted when hitting
+              backspace from inside an Aloha Editor UI.
+- **BUGFIX**: This change fixes the behaviour of linebreaks by preventing
+              paragraphs to be inserted inside editable spans and paragraphs,
+              and improves the editor's robustness against errors when inserting paragraphs.

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -7835,6 +7835,12 @@ define(['aloha/core', 'aloha/ecma5shims', 'util/maps', 'util/html', 'jquery'], f
 				);
 			}
 
+			// If no container has been set yet, it is not possible to insert a paragraph at this position;
+			// the following steps are skipped in order to prevent critical errors from occurring;
+			if (!container) {
+				return;
+			}
+
 			// "If container's local name is "address", "listing", or "pre":"
 			var oldHeight, newHeight;
 			if (container.tagName == "ADDRESS" || container.tagName == "LISTING" || container.tagName == "PRE") {

--- a/src/lib/aloha/markup.js
+++ b/src/lib/aloha/markup.js
@@ -27,6 +27,7 @@
 define([
 	'aloha/core',
 	'util/class',
+	'util/html',
 	'jquery',
 	'aloha/ecma5shims',
 	'aloha/console',
@@ -34,6 +35,7 @@ define([
 ], function (
 	Aloha,
 	Class,
+	Html,
 	jQuery,
 	shims,
 	console,
@@ -384,14 +386,13 @@ define([
 
 			// ENTER
 			if (event.keyCode === 13) {
-				if (event.shiftKey) {
+				if (event.shiftKey || !Html.allowNestedParagraph(Aloha.activeEditable)) {
 					Aloha.execCommand('insertlinebreak', false);
 					return false;
 				}
 				Aloha.execCommand('insertparagraph', false);
 				return false;
 			}
-
 			return true;
 		},
 

--- a/src/lib/util/html.js
+++ b/src/lib/util/html.js
@@ -160,6 +160,21 @@ define([
 		return node;
 	}
 
+	/**
+	 * Checks if the given editable is a valid container for paragraphs.
+	 *
+	 * @param {Aloha.Editable} editable The editable to be checked
+	 *
+	 * @return {boolean} False if the editable may not contain paragraphs
+	 */
+	function allowNestedParagraph(editable) {
+		if (editable.obj.prop("tagName") === "SPAN" ||
+				editable.obj.prop("tagName") === "P") {
+			return false;
+		}
+		return true;
+	}
+
 	return {
 		BLOCKLEVEL_ELEMENTS: BLOCKLEVEL_ELEMENTS,
 		isBlock: isBlock,
@@ -167,6 +182,7 @@ define([
 		isInlineFormattable: isInlineFormattable,
 		isProppedBlock: isProppedBlock,
 		isEditingHost: isEditingHost,
-		findNodeRight: findNodeRight
+		findNodeRight: findNodeRight,
+		allowNestedParagraph: allowNestedParagraph
 	};
 });


### PR DESCRIPTION
Please consider :)
Changelog: This change fixes the behaviour of linebreaks by preventing paragraphs to be inserted inside editable spans and paragraphs, and improves the editor's robustness against errors when inserting paragraphs. 
