### PR TITLE
Fix enter behaviour in editables that cannot contain paragraphs

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -8,3 +8,6 @@ All changes are categorized into one of the following keywords:
 
 ----
 
+- **BUGFIX**: With this change, paragraphs are no longer inserted when pressing Enter
+              in editables that do not allow paragraphs to be contained inside (according
+              to the HTML 5 standard). In this case, a linebreak is added instead.

--- a/src/lib/aloha/markup.js
+++ b/src/lib/aloha/markup.js
@@ -386,12 +386,15 @@ define([
 
 			// ENTER
 			if (event.keyCode === 13) {
-				if (event.shiftKey || !Html.allowNestedParagraph(Aloha.activeEditable)) {
+				if (!event.shiftKey && Html.allowNestedParagraph(Aloha.activeEditable)) {
+					Aloha.execCommand('insertparagraph', false);
+					return false;
+				// if the shift key is pressed, or if the active editable is not allowed
+				// to contain paragraphs, a linebreak is inserted instead
+				} else {
 					Aloha.execCommand('insertlinebreak', false);
 					return false;
 				}
-				Aloha.execCommand('insertparagraph', false);
-				return false;
 			}
 			return true;
 		},

--- a/src/lib/util/html.js
+++ b/src/lib/util/html.js
@@ -25,10 +25,12 @@
  * recipients can access the Corresponding Source.
  */
 define([
-	'util/dom2',
+	'jquery',
+	'util/dom',
 	'util/maps',
 	'util/arrays'
 ], function (
+	jQuery,
 	Dom,
 	Maps,
 	Arrays
@@ -168,11 +170,10 @@ define([
 	 * @return {boolean} False if the editable may not contain paragraphs
 	 */
 	function allowNestedParagraph(editable) {
-		if (editable.obj.prop("tagName") === "SPAN" ||
-				editable.obj.prop("tagName") === "P") {
-			return false;
+		if (editable.obj[0] && Dom.allowsNesting(editable.obj[0], jQuery("<p>")[0])) {
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 	return {


### PR DESCRIPTION
If the active editable does not allow paragraphs as its content (according
to http://www.w3.org/TR/2010/WD-html-markup-20101019/p.html, the element
must allow flow content), a linebreak is inserted instead of a paragraph
when pressing the Enter key, as if using shift-Enter.
