### PR TITLE
Upgrade Rangy from 1.2.1 to 1.3alpha.772

### DIFF
--- a/src/lib/vendor/rangy-core.js
+++ b/src/lib/vendor/rangy-core.js
@@ -3651,3 +3651,6 @@ rangy.createModule("WrappedSelection", function(api, module) {
 		win = null;
 	});
 });
+
+// TODO we should avoid populating the global namespace
+window.rangy = rangy;


### PR DESCRIPTION
We had a lot of weird problems in Firefox and IE which was related to Rangy. Upgrading to 1.3 seems to fix most of them. Don't know if you're happy about upgrading though ..
