### PR TITLE
Hotfix inline blocks fixes, pad/unpad when inserted.

### DIFF
--- a/src/plugins/common/block/lib/block-utils.js
+++ b/src/plugins/common/block/lib/block-utils.js
@@ -46,7 +46,9 @@ define([
 		var previous = Dom.findBackward(
 			Dom.backward($block[0]),
 			isVisibleNode,
-			DomLegacy.isEditingHost
+			function(node) {
+				return Html.isBlock(node) || DomLegacy.isEditingHost(node);
+			}
 		);
 		if (!previous) {
 			$block.before(createLandingElement());
@@ -55,7 +57,7 @@ define([
 			skipNodeForward($block[0]),
 			isVisibleNode,
 			function (node) {
-				return DomLegacy.isEditingHost(node) || (
+				return Html.isBlock(node) || DomLegacy.isEditingHost(node) || (
 					node.previousSibling
 					&&
 					DomLegacy.isEditingHost(node.previousSibling)

--- a/src/plugins/common/block/lib/block.js
+++ b/src/plugins/common/block/lib/block.js
@@ -38,7 +38,8 @@ define([
 	'ui/scopes',
 	'util/class',
 	'PubSub',
-	'block/block-utils'
+	'block/block-utils',
+	'util/html'
 ], function(
 	Aloha,
 	jQuery,
@@ -47,7 +48,8 @@ define([
 	Scopes,
 	Class,
 	PubSub,
-	BlockUtils
+	BlockUtils,
+    Html
 ){
 	'use strict';
 
@@ -182,10 +184,14 @@ define([
 			//	}
 			//});
 
-			// Only for the span element.
+			// Only for inline element.
 			// It is not possible to insert text after or before a Block span
 			// when after or before the Block there is not elements
-			if (this.$element[0].nodeName === 'SPAN') {
+			if (Html.isInlineFormattable($element[0])) {
+				if ($element.parents('.aloha-editable-active').length > 0) {
+					BlockUtils.pad(that.$element);
+				}
+
 				Aloha.bind('aloha-editable-activated', function ($event, data) {
 					if (data.editable) {
 						var $block = data.editable.obj.find('#' + that.id);


### PR DESCRIPTION
· Pad/Unpad a block when is inserted in an active editable tag.
· Fixes when after a block there is a p tag.
