### PR TITLE
Inputs Image Height/Width don't display when image is load (ie9)

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -17,3 +17,7 @@ All changes are categorized into one of the following keywords:
               size-check of image-resizing
 - **BUGFIX**: image plugin: Various fixes and improvements for resizing, cropping and resetting images have been added, 
               to improve the cohesion between displayed values and actual sizes.
+- **BUGFIX**: Inputs Image Height/Width don't display when image is load (ie9)
+              When selecting a image in content.Node the width and height inputs were not displayed.
+              The problem was that when assigning the value to the input, the jQuery.val function was not
+              working, maybe because the element wasn't associated to the DOM yet.

--- a/src/plugins/common/image/lib/image-plugin.js
+++ b/src/plugins/common/image/lib/image-plugin.js
@@ -970,10 +970,9 @@ define([
 		 * Helper function that will set the new image size using the field values
 		 */
 		setSizeByFieldValue: function () {
-			var plugin = this;
-			var width =  $('#' + plugin.ui.imgResizeWidthField.getInputId()).val();
-			var height = $('#' + plugin.ui.imgResizeHeightField.getInputId()).val();
-			plugin.setSize(width, height);
+			var width =  this.ui.imgResizeWidthField.getValue();
+			var height = this.ui.imgResizeHeightField.getValue();
+			this.setSize(width, height);
 		},
 
 		/**
@@ -982,10 +981,11 @@ define([
 		 * @param height new image-height in pixels
 		 */
 		_applyValuesToFields: function (width, height) {
-			$("#" + this.ui.imgResizeWidthField.getInputId()).val(width);
-			$("#" + this.ui.imgResizeHeightField.getInputId()).val(height);
-			$('#' + this.ui.imgResizeWidthField.getInputId()).css('background-color', '');
-			$('#' + this.ui.imgResizeHeightField.getInputId()).css('background-color', '');
+			this.ui.imgResizeWidthField.setValue(width);
+			this.ui.imgResizeHeightField.setValue(height);
+
+			this.ui.imgResizeWidthField.getInputJQuery().css('background-color', '');
+			this.ui.imgResizeHeightField.getInputJQuery().css('background-color', '');
 		},
 
 		/**
@@ -997,20 +997,16 @@ define([
 		 * when calculating the field values
 		 */
 		setCropAreaByFieldValue: function () {
+			var currentCropArea = this.jcAPI.tellSelect();
 
-			var plugin = this;
-			var currentCropArea = plugin.jcAPI.tellSelect();
-
-			var width =  $('#' + plugin.ui.imgResizeWidthField.getInputId()).val();
-			width = parseInt(width, 10);
-			var height = $('#' + plugin.ui.imgResizeHeightField.getInputId()).val();
-			height = parseInt(height, 10);
+			var width =  parseInt(this.ui.imgResizeWidthField.getValue(), 10);
+			var height = parseInt(this.ui.imgResizeHeightField.getValue(), 10);
 
 			var selection = [currentCropArea['x'], currentCropArea['y'], currentCropArea['x'] + width,currentCropArea['y'] + height];
 
-			plugin.jcAPI.setSelect(selection);
-			plugin._onCropSelect();
-			plugin.jcAPI.enable();
+			this.jcAPI.setSelect(selection);
+			this._onCropSelect();
+			this.jcAPI.enable();
 		},
 
 		/**

--- a/src/plugins/common/ui/lib/port-helper-attribute-field.js
+++ b/src/plugins/common/ui/lib/port-helper-attribute-field.js
@@ -412,6 +412,10 @@ define([
 			return element[0];
 		}
 
+		function getInputJQuery() {
+			return element;
+		}
+
 		var attrField = {
 			getInputElem: getInputElem,
 			hasInputElem: hasInputElem,
@@ -430,7 +434,8 @@ define([
 			addListener: addListener,
 			setObjectTypeFilter: setObjectTypeFilter,
 			setTemplate: setTemplate,
-			setPlaceholder: setPlaceholder
+			setPlaceholder: setPlaceholder,
+			getInputJQuery: getInputJQuery
 		};
 
 		return attrField;


### PR DESCRIPTION
When selecting a image in content.Node the width and height inputs were not displayed. The problem was that when assigning the value to the input, the jQuery.val function was not working, maybe because the element wasn't associated to the DOM yet.
