### PR TITLE
'th' tag 'scope' attribute set to 'column'

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -25,3 +25,8 @@ All changes are categorized into one of the following keywords:
 
 - **BUGFIX**: tables: It is now possible to delete entire rows or columns using
               the delete key.
+
+- **BUGFIX**:'scope' attribute set to 'column'.
+
+             The vale 'column' for the 'scope' attribute in 'th' Tag element is not valid.
+             This attribute only accept 'col' or 'row' values. RT#56088

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -787,7 +787,7 @@ define([
 				if (that.activeTable) {
 					that.activeTable.refresh();
 
-					toggleHeaderStatus(that.activeTable, 'column');
+					toggleHeaderStatus(that.activeTable, 'col');
 
 					that.activeTable.selection.unselectCells();
 					that.activeTable.selection.selectRows(that.activeTable.selection.selectedRowIdxs);


### PR DESCRIPTION
The options for the 'scope' attribute are 'row' or 'col'.

RT#56088
