### PR TITLE
Formatless Copy/Paste not working.

### DIFF
--- a/build/dev-changelog.md
+++ b/build/dev-changelog.md
@@ -7,4 +7,3 @@ All changes are categorized into one of the following keywords:
                    functional change to any feature.
 
 ----
-

--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -25,3 +25,8 @@ All changes are categorized into one of the following keywords:
 
 - **BUGFIX**: tables: It is now possible to delete entire rows or columns using
               the delete key.
+
+- **BUGFIX**: Formatless Copy/Paste not working.
+              When paste action was made the formatlesshandler was never called.
+              We manually call this handler before pasting the content into the DOM element.
+              RT#56692

--- a/src/lib/util/html.js
+++ b/src/lib/util/html.js
@@ -111,6 +111,45 @@ define([
 	];
 
 	/**
+	 * Text-level semantic and edit elements to be remove during
+	 * copying or pasting.
+	 *
+	 * See:
+	 * http://dev.w3.org/html5/spec/text-level-semantics.html#usage-summary
+	 *
+	 * Configurable.
+	 *
+	 * @type {Array.<string>}
+	 */
+	var STRIPPED_ELEMENTS = ['a',
+		'abbr',
+		'b',
+		'bdi',
+		'bdo',
+		'cite',
+		'code',
+		'del',
+		'dfn',
+		'em',
+		'i',
+		'ins',
+		'kbd',
+		'mark',
+		'q',
+		'rp',
+		'rt',
+		'ruby',
+		's',
+		'samp',
+		'small',
+		'strong',
+		'sub',
+		'sup',
+		'time',
+		'u',
+		'var'];
+
+	/**
 	 * Unicode zero width space characters:
 	 * http://www.unicode.org/Public/UNIDATA/Scripts.txt
 	 *
@@ -320,6 +359,7 @@ define([
 	return {
 		BLOCKLEVEL_ELEMENTS: BLOCKLEVEL_ELEMENTS,
 		VOID_ELEMENTS: VOID_ELEMENTS,
+		STRIPPED_ELEMENTS: STRIPPED_ELEMENTS,
 		isBlock: isBlock,
 		isIgnorableWhitespace: isIgnorableWhitespace,
 		isInlineFormattable: isInlineFormattable,

--- a/src/plugins/common/paste/lib/paste-plugin.js
+++ b/src/plugins/common/paste/lib/paste-plugin.js
@@ -38,7 +38,8 @@ define([
 	'contenthandler/contenthandler-utils',
 	'aloha/console',
 	'aloha/copypaste',
-	'util/dom'
+	'util/dom',
+	'aloha/contenthandlermanager'
 ], function (
 	$,
 	Aloha,
@@ -47,7 +48,8 @@ define([
 	ContentHandlerUtils,
 	Console,
 	CopyPaste,
-	Dom
+	Dom,
+	ContentHandlerManager
 ) {
 	'use strict';
 
@@ -315,6 +317,11 @@ define([
 			});
 
 			var content = $clipboard.html();
+
+			var formatlessHandler = ContentHandlerManager.get('formatless');
+			if (typeof formatlessHandler !== 'undefined') {
+				content = formatlessHandler.handleContent(content);
+			}
 
 			// Because IE inserts an insidious nbsp into the content during
 			// pasting that needs to be removed.  Leaving it would otherwise

--- a/src/plugins/extra/formatlesspaste/lib/formatlesspaste-plugin.js
+++ b/src/plugins/extra/formatlesspaste/lib/formatlesspaste-plugin.js
@@ -32,7 +32,8 @@ define([
 	'ui/toggleButton',
 	'formatlesspaste/formatlesshandler',
 	'aloha/contenthandlermanager',
-	'i18n!formatlesspaste/nls/i18n'
+	'i18n!formatlesspaste/nls/i18n',
+	'util/html'
 ], function (
 	Aloha,
 	Plugin,
@@ -41,7 +42,8 @@ define([
 	ToggleButton,
 	FormatlessPasteHandler,
 	ContentHandlerManager,
-	i18n
+	i18n,
+    Html
 ) {
 	'use strict';
 
@@ -83,7 +85,7 @@ define([
 
 	function registerFormatlessPasteHandler(plugin) {
 		ContentHandlerManager.register('formatless', FormatlessPasteHandler);
-		FormatlessPasteHandler.strippedElements = plugin.strippedElements;
+		FormatlessPasteHandler.strippedElements = Html.STRIPPED_ELEMENTS;
 
 		plugin._toggleFormatlessPasteButton =
 			Ui.adopt('toggleFormatlessPaste', ToggleButton, {
@@ -156,45 +158,6 @@ define([
 		 * @type {boolean}
 		 */
 		button: true,
-
-		/**
-		 * Text-level semantic and edit elements to be remove during
-		 * copying or pasting.
-		 *
-		 * See:
-		 * http://dev.w3.org/html5/spec/text-level-semantics.html#usage-summary
-		 *
-		 * Configurable.
-		 *
-		 * @type {Array.<string>}
-		 */
-		strippedElements: ['a',
-		                   'abbr',
-		                   'b',
-		                   'bdi',
-		                   'bdo',
-		                   'cite',
-		                   'code',
-		                   'del',
-		                   'dfn',
-		                   'em',
-		                   'i',
-		                   'ins',
-		                   'kbd',
-		                   'mark',
-		                   'q',
-		                   'rp',
-		                   'rt',
-		                   'ruby',
-		                   's',
-		                   'samp',
-		                   'small',
-		                   'strong',
-		                   'sub',
-		                   'sup',
-		                   'time',
-		                   'u',
-		                   'var'],
 
 		/**
 		 * Initializes formatless copying and pasting.


### PR DESCRIPTION
When paste action was made the formatlesshandler was never called. We manually call this handler before pasting the content into the DOM element.

RT#56692
