### PR TITLE
Table caption is removed every time is deactivated.

### DIFF
--- a/build/dev-changelog.md
+++ b/build/dev-changelog.md
@@ -7,4 +7,3 @@ All changes are categorized into one of the following keywords:
                    functional change to any feature.
 
 ----
-

--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -7,3 +7,7 @@ All changes are categorized into one of the following keywords:
                    usage, or intent of an existing one.
 
 ----
+
+- **BUGFIX**: Table caption is removed every time is deactivated.
+              Table caption is now hidden or shown but not removed,
+              so the original text remains. RT#56649

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -1116,16 +1116,24 @@ define([
 			click: function() {
 				if (that.activeTable) {
 					// look if table object has a child caption
-					if ( that.activeTable.obj.children("caption").is('caption') ) {
-						that.activeTable.obj.children("caption").remove();
+					var $caption = that.activeTable.obj.children("caption");
+
+					if ( $caption.is('caption') && $caption.is(':visible') ) {
+						$caption.hide();
 					} else {
-						var captionText = i18n.t('empty.caption');
-						var c = jQuery('<caption></caption>');
-						that.activeTable.obj.prepend(c);
-						that.makeCaptionEditable(c, captionText);
+						if (!$caption.is('caption')) {
+							$caption = jQuery('<caption></caption>');
+							that.activeTable.obj.prepend($caption);
+						}
+						$caption.show();
+						if (jQuery.trim($caption.text()).length === 0) {
+							$caption.text(i18n.t('empty.caption'));
+						}
+
+						that.makeCaptionEditable($caption, $caption.text());
 
 						// get the editable span within the caption and select it
-						var cDiv = c.find('div').eq(0);
+						var cDiv = $caption.find('div').eq(0);
 						var captionContent = cDiv.contents().eq(0);
 						if (captionContent.length > 0) {
 							var newRange = new GENTICS.Utils.RangeObject();


### PR DESCRIPTION
Table caption is now hidden or shown but not removed, so the original text remains.
