### PR TITLE
Copy table from Word/Excel

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -7,3 +7,6 @@ All changes are categorized into one of the following keywords:
                    usage, or intent of an existing one.
 
 ----
+
+- **BUGFIX**: 'width' attribute from table not removed
+              When copying the table the 'width' attribute of is not removed. RT#55759

--- a/src/plugins/common/contenthandler/lib/genericcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/genericcontenthandler.js
@@ -119,7 +119,7 @@ define([
 
 		// Because Aloha does not provide a means for editors to manipulate
 		// these properties.
-		$content.find('td,tr')
+		$content.find('table,th,td,tr')
 			.removeAttr('width')
 			.removeAttr('height')
 			.removeAttr('valign');
@@ -128,7 +128,7 @@ define([
 		// @TODO Use sanitize.js?
 		$content.find('colgroup').remove();
 	}
-	
+
 	/**
 	 * Return true if the nodeType is allowed in the settings,
 	 * Aloha.settings.contentHandler.allows.elements
@@ -174,7 +174,6 @@ define([
 			}
 
 			prepareTables($content);
-
 			this.cleanLists($content);
 			this.removeComments($content);
 			this.unwrapTags($content);


### PR DESCRIPTION
When copying the table format needs some adjust. 'colgroup' is no necessary, 'width' or 'height' attributes duplicates in css 'width' and 'height' properties,  'font' tag (only IE) is deprecated so it must be deleted.
