### PR TITLE
Table Plugin: table selection issues

### DIFF
--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -457,9 +457,10 @@ define([
 		// deselect all highlighted cells registered in the this.tableObj.selection object
 		this.tableObj.selection.unselectCells();
 
-		if (this.tableObj.hasFocus) {
-			if (!Browser.ie)
-				jqEvent.stopPropagation();
+		if (typeof jqEvent.stopPropagation === 'function') {
+			jqEvent.stopPropagation();
+		} else if (typeof jqEvent.cancelBubble !== 'undefined') {
+			jqEvent.cancelBubble = true;
 		}
 	};
 

--- a/src/plugins/common/table/lib/table-selection.js
+++ b/src/plugins/common/table/lib/table-selection.js
@@ -166,13 +166,16 @@ define([
 	TableSelection.prototype.notifyCellsSelected = function () {
 		Aloha.trigger( 'aloha-table-selection-changed' );
 		
-		// the UI feels more consisten when we remove the non-table
+		// the UI feels more consistent when we remove the non-table
 		// selection when cells are selected
 		// TODO this code doesn't work right in IE as it causes the table
 		//  scope of the floating menu to be lost. Maybe this can be
 		//  handled by testing for an empty selection in the
 		//  aloha-selection-changed event.
-		//Aloha.getSelection().removeAllRanges();
+		var selection = Aloha.getSelection();
+		if (selection.getRangeCount() > 0) {
+			selection.removeAllRanges();
+		}
 	};
 
 	/**


### PR DESCRIPTION
When having several tables and click text inside one, the whole text is no selected anymore.
Now a cells selection can start in the middle of the text inside a table cell.
