### PR TITLE
Table Plugin: select row/col in IE7, IE8 does not show Table Row/Col panel

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -9,3 +9,5 @@ All changes are categorized into one of the following keywords:
 ----
 
 - **BUGFIX**:	image-plugin: The image plugin icons were fixed for IE7+
+- **BUGFIX**:   table-plugin: Table selection for rows or columns in IE8 did not show Table Row/Column
+                              panel options. This error is fixed.

--- a/src/lib/util/browser.js
+++ b/src/lib/util/browser.js
@@ -28,6 +28,7 @@ define(['jquery'], function ($) {
 	'use strict';
 	return {
 		ie7: $.browser.msie && parseInt($.browser.version, 10) < 8,
+		ie8: $.browser.msie && parseInt($.browser.version, 10) < 9,
 		ie : $.browser.msie
 	};
 });

--- a/src/plugins/common/table/lib/table-plugin-utils.js
+++ b/src/plugins/common/table/lib/table-plugin-utils.js
@@ -7,7 +7,7 @@ define([
 	$,
 	CopyPaste,
 	Browser,
-    Console
+	Console
 ) {
 	'use strict';
 
@@ -530,11 +530,11 @@ define([
 			var anchor = getAnchorCell(selection);
 			if (anchor) {
 				var element = $('>.aloha-table-cell-editable', anchor)[0];
-				if (Browser.ie7) {
+				if (Browser.ie7 || Browser.ie8) {
 					try {
-						CopyPaste.selectAllOf(element)
+						CopyPaste.selectAllOf(element);
 					} catch (e) {
-						Console.error ('Table', e.message);
+						Console.warn('Table Plugin', e.message);
 					}
 				} else {
 					CopyPaste.selectAllOf(element);


### PR DESCRIPTION
Selecting row/col throw a javascript exception (﻿range [WrappedRange(<DIV>[1]:0, <DIV>[1]:1)] did not consist of a single element) which causes that the  Table Row/Col Panel is not displayed. The problem resides in the rangy-core and how it deals with selection for IE7 and IE8. The selection for this versions behaves different than for earlier version (IE9+).
