### PR TITLE
Correct browser support detection

### DIFF
--- a/src/lib/aloha/core.js
+++ b/src/lib/aloha/core.js
@@ -44,8 +44,10 @@ define([
 		var browser = $.browser;
 		var version = browser.version;
 		return !(
-			// Chrome/Safari 4
-			(browser.webkit && parseFloat(version) < 532.5) ||
+			// Chrome 21
+			(browser.chrome && parseFloat(version) < 21) ||
+			// Safari 4
+			(browser.webkit && !browser.chrome && parseFloat(version) < 532.5) ||
 			// FF 3.5
 			(browser.mozilla && parseFloat(version) < 1.9) ||
 			// IE 7


### PR DESCRIPTION
Since jQuery version 1.8.x, the jQuery.browser information object changed, which caused false negatives when detecting Chrome.
