### PR TITLE
Don't call `unbind()` on undefined objects

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -18,3 +18,8 @@ All changes are categorized into one of the following keywords:
               aligned, but only the content that is selected (up to the nearest
               block-level element).
 
+- **BUGFIX**: drag-n-drop: Dragging a block element into an non-editable region
+              resulted in a JavaScript error. This error caused HTML artifacts
+              to be left in the region. Fixing the  JavaScript error corrects
+              this behavior. RT#57629
+

--- a/src/plugins/common/block/lib/dragbehavior.js
+++ b/src/plugins/common/block/lib/dragbehavior.js
@@ -271,7 +271,7 @@ define([
 	};
 
 	/**
-	 * Check the element that is below of the draggable element in a drag
+	 * Checks the element that is below of the draggable element in a drag
 	 * operation, if is a valid element, this method call to highlight methods
 	 *
 	 * @param {HTMLElement} elm
@@ -280,14 +280,12 @@ define([
 	 * @return {Boolean}
 	 */
 	DragBehavior.prototype.onMouseover = function (elm, event) {
-		if (this.$overElement) {
-			this.disableInsertBeforeOrAfter(this.$overElement);
-		}
+		this.disableInsertBeforeOrAfter(this.$overElement);
 		this.$overElement = $(elm);
 		if (!this._isAllowedOverElement(elm)) {
 			this.enableInsertBeforeOrAfter(elm);
 
-			return true; // to continue bubbleing to find a element where can insert the block
+			return true; // to continue bubbling to find a element where can insert the block
 		} else {
 			this.highlightElement(elm);
 			event.stopImmediatePropagation();
@@ -359,7 +357,9 @@ define([
 	 */
 	DragBehavior.prototype.disableInsertBeforeOrAfter = function ($elm) {
 		this.insertBeforeOrAfterMode = false;
-		$elm.unbind('.brIBOA');
+		if ($elm) {
+			$elm.unbind('.brIBOA');
+		}
 	};
 
 	/**
@@ -444,7 +444,6 @@ define([
 		}
 
 		this.disableInsertBeforeOrAfter(this.$overElement);
-
 	};
 
 	/**


### PR DESCRIPTION
Dragging a block element into an non-editable region resulted in a
JavaScript error. This error caused HTML artifacts to be left in the
region instead of aborting.
