### PR TITLE
Copy and paste text from MS-Word in IE9 browser adds line breaks

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -23,3 +23,11 @@ All changes are categorized into one of the following keywords:
               to be left in the region. Fixing the  JavaScript error corrects
               this behavior. RT#57629
 
+- **BUGFIX**: copy-pate: Copy and paste text content from MS-Word to Aloha content
+              in IE9 Browser, added line break between paragraphs. When
+              copying from MS-Word unrendered whitespaces are added between
+              paragraphs and are rendered as lines break for Aloha Editor.
+              Removing these unrendered whitespaces solves the line break problem.
+              RT#57725
+
+

--- a/src/plugins/common/contenthandler/lib/wordcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/wordcontenthandler.js
@@ -29,13 +29,15 @@ define([
 	'aloha',
 	'aloha/contenthandlermanager',
 	'contenthandler/contenthandler-utils',
-	'util/dom'
+	'util/dom2',
+	'util/html'
 ], function (
 	$,
 	Aloha,
 	Manager,
 	Utils,
-	Dom
+	Dom2,
+    Html
 ) {
 	'use strict';
 
@@ -110,6 +112,22 @@ define([
 	}
 
 	/**
+	 * Removes unrendered child nodes from `$content`.
+	 * @param {jQuery.<HTMLElement> $content
+	 */
+	function removeUnrenderedChildNodes($content) {
+		var childNodes = $content[0].childNodes;
+		var i;
+		var len;
+
+		for (i = 0, len = childNodes.length; i < len; i++) {
+			if (childNodes[i] && Html.isUnrenderedNode(childNodes[i])) {
+				$content[0].removeChild(childNodes[i]);
+			}
+		}
+	}
+
+	/**
 	 * Cleanup MS Word HTML.
 	 *
 	 * @param {jQuery.<HTMLElement>} $content
@@ -120,7 +138,9 @@ define([
 		var $node;
 		var href;
 		var i;
-		for (i = 0; i < $nodes.length; i++) {
+		var len;
+
+		for (i = 0, len = $nodes.length; i < len; i++) {
 			$node = $nodes.eq(i);
 			nodeName = $node[0].nodeName.toLowerCase();
 
@@ -144,6 +164,8 @@ define([
 				$node.contents().unwrap();
 			}
 		}
+
+		removeUnrenderedChildNodes($content);
 	}
 
 	/**
@@ -399,7 +421,7 @@ define([
 						if ( jQuery.trim(jQuery(this).text()).match(/^([\.\(]?[\d\D][\.\(]?){1,4}$/) ) {
 							jQuery(this).remove();
 						}
-					})
+					});
 				
 					// remove TOC anchor links
 					links.each(function() {


### PR DESCRIPTION
Copy and paste text content from MS-Word to Aloha content in IE9 Browser, added lines break between paragraphs. When copying from MS-Word unrendered whitespaces are added between paragraphs and are rendered as lines break for Aloha Editor. Removing these unrendered whitespaces solves the line break problem
