### PR TITLE
'Insert Table' button tooltip does not disappear

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -30,4 +30,8 @@ All changes are categorized into one of the following keywords:
               Removing these unrendered whitespaces solves the line break problem.
               RT#57725
 
+- **BUGFIX**: button tooltip: 'Insert Table' button tooltip did not disappear when selecting
+              the rows and the columns of the table. This has been fixed so the tooltip does
+              disappear. RT#57677
+
 

--- a/src/plugins/common/ui/lib/button.js
+++ b/src/plugins/common/ui/lib/button.js
@@ -60,10 +60,14 @@ function (jQuery, Component, Utils) {
 					// cells are merged or split.
 					// IE needs the force argument to be true, Chrome doesn't.
 					// The event argument can be ignored.
-					this.buttonElement.tooltip('close', null/*event*/, true/*force*/);
+					this.closeTooltip();
 
 					this._onClick();
 				}, this));
+		},
+
+		closeTooltip: function() {
+			this.buttonElement.tooltip('close', null/*event*/, true/*force*/);
 		},
 
 		/**
@@ -89,10 +93,17 @@ function (jQuery, Component, Utils) {
 		 */
 		createButtonElement: function () {
 			var button = Utils.makeButtonElement();
+
 			if (this['class']) {
 				button.addClass(this['class']);
 			}
 			this.element = this.buttonElement = button;
+
+			var that = this;
+			button.bind('mouseleave', function() {
+				that.closeTooltip();
+			});
+
 			return button;
 		},
 


### PR DESCRIPTION
When selecting the rows and the columns of the table the 'Insert Table' button tooltip did not disappear. Now every time the mouse cursor leaves the button area, the tooltip will be closed.
