### PR TITLE
(FF) New row with Tab keydown sets the cursor in the first Cell

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -8,4 +8,8 @@ All changes are categorized into one of the following keywords:
 
 ----
 
+- **BUGFIX**: table-plugin: (Firefox) Pressing tab in the last cell of last
+              row creates a row, but the cursor was placed outside the
+              table. With this fix the cursor is placed in the first cell of
+              the created row. #RT57686
 

--- a/src/lib/util/browser.js
+++ b/src/lib/util/browser.js
@@ -29,6 +29,7 @@ define(['jquery'], function ($) {
 	return {
 		ie7: $.browser.msie && parseInt($.browser.version, 10) < 8,
 		ie8: $.browser.msie && parseInt($.browser.version, 10) < 9,
-		ie : $.browser.msie
+		ie : $.browser.msie,
+		mozilla : $.browser.mozilla
 	};
 });

--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -2,12 +2,14 @@ define([
 	'aloha',
 	'aloha/jquery',
 	'aloha/ephemera',
-	'table/table-plugin-utils'
+	'table/table-plugin-utils',
+	'util/browser'
 ], function (
 	Aloha,
 	jQuery,
 	Ephemera,
-	Utils
+	Utils,
+    Browser
 ) {
 	/**
 	 * Constructs a TableCell.
@@ -480,6 +482,16 @@ define([
 	};
 
 	/**
+	 * Sets cursor in `cell`.
+	 * @param {HTMLTableCellElement} cell
+	 */
+	function setCursorInCell(cell) {
+		var refNode = cell.querySelector('.aloha-table-cell-editable');
+
+		$(refNode).focus();
+	}
+
+	/**
 	 * The key-down event for the ediable-div in the td-field. Check if the the div
 	 * is empty and insert an &nbsp. Furthermore if cells are selected, unselect
 	 * them.
@@ -495,7 +507,17 @@ define([
 			// only add a row on a single key-press of tab (so check that alt-,
 			// shift- or ctrl-key are NOT pressed)
 			if (KEYCODE_TAB == jqEvent.keyCode && !jqEvent.altKey && !jqEvent.shiftKey && !jqEvent.ctrlKey) {
-				this.tableObj.addRow(this.obj.parent().index() + 1);
+				var lastInsertedRow = this.tableObj.addRow(this.obj.parent().index() + 1);
+
+				if (Browser.mozilla) {
+					// After the row is inserted, mozilla sets the cursor outside
+					// the Table in weird places.
+					jqEvent.preventDefault();
+
+					// The first 'td' element is the empty cell for row selecting
+					var firstCell = lastInsertedRow.querySelector('td').nextElementSibling;
+					setCursorInCell(firstCell);
+				}
 			}
 		}
 	};

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -1425,36 +1425,37 @@ define([
 	 *
 	 * @param {int} rowIndex
 	 *        the index at which the new row shall be inserted
+	 * @return <HTMLElemenet> last row inserted
 	 */
 	Table.prototype.addRow = function(newRowIndex) {
-
-		var that = this;
 		var rowsToInsert = 1;
+		var $insertionRow;
+		var classSelectionColumn = this.get('classSelectionColumn');
 
-		var numCols = this.countVirtualCols();
 		var $rows = this.obj.children().children('tr');
 		for (var j = 0; j < rowsToInsert; j++) {
-			var insertionRow = jQuery('<tr>');
+			$insertionRow = jQuery('<tr>');
 
 			// create the first column, the "select row" column
-			var selectionColumn = jQuery('<td>');
-			selectionColumn.addClass(this.get('classSelectionColumn'));
-			this.attachRowSelectionEventsToCell(selectionColumn);
-			insertionRow.append(selectionColumn);
+			var $selectionColumn = jQuery('<td>');
+			$selectionColumn.addClass(classSelectionColumn);
+			this.attachRowSelectionEventsToCell($selectionColumn);
+			$insertionRow.append($selectionColumn);
 
 			var grid = Utils.makeGrid($rows);
 			var selectColOffset = 1;
 			if ( newRowIndex >= grid.length ) {
 				for (var i = selectColOffset; i < grid[0].length; i++) {
-					insertionRow.append(this.newActiveCell().obj);
+					$insertionRow.append(this.newActiveCell().obj);
 				}
 			} else {
-				for (var i = selectColOffset; i < grid[newRowIndex].length; ) {
-					var cellInfo = grid[newRowIndex][i];
+				var newRow = grid[newRowIndex];
+				for (var i = selectColOffset, len = newRow.length; i < len; ) {
+					var cellInfo = newRow[i];
 					if (Utils.containsDomCell(cellInfo)) {
 						var colspan = cellInfo.colspan;
 						while (colspan--) {
-							insertionRow.append(this.newActiveCell().obj);
+							$insertionRow.append(this.newActiveCell().obj);
 						}
 					} else {
 						jQuery( cellInfo.cell ).attr('rowspan', cellInfo.rowspan + 1);
@@ -1464,13 +1465,15 @@ define([
 			}
 
 			if ( newRowIndex >= $rows.length ) {
-				$rows.eq( $rows.length - 1 ).after( insertionRow );
+				$rows.eq( $rows.length - 1 ).after( $insertionRow );
 			} else {
-				$rows.eq( newRowIndex ).before( insertionRow );
+				$rows.eq( newRowIndex ).before( $insertionRow );
 			}
 		}
 
 		this.numRows += rowsToInsert;
+
+		return $insertionRow[0];
 	};
 
 	/**


### PR DESCRIPTION
(Only Firefox) Pressing tab in the last cell of last row, creates a new row but the cursor was set outside the table. We manually put the cursor in the first cell of the new row just by calling  firstCell.focus(). This is only a Firefox issue
