### PR TITLE
Link plugin: click once to open link properties Tab

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -34,4 +34,6 @@ All changes are categorized into one of the following keywords:
               the rows and the columns of the table. This has been fixed so the tooltip does
               disappear. RT#57677
 
-
+- **BUGFIX**: link plugin: When typing the URL for a link and then pressing Enter,
+              it creates the link but you must click tow times to open the link
+              properties. The fix allows the user to click just once. RT#57711

--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -613,12 +613,7 @@ define( [
 				if (Keys.getToken(event.keyCode) === 'enter') {
 					// Update the selection and place the cursor at the end of the link.
 					var	range = Aloha.Selection.getRangeObject();
-					
-					// workaround to keep the found markup otherwise removelink won't work
-//					var foundMarkup = that.findLinkMarkup( range );
-//					console.dir(foundMarkup);
-//					that.hrefField.setTargetObject(foundMarkup, 'href');
-					
+
 					// We have to ignore the next 2 onselectionchange events.
 					// The first one we need to ignore is the one trigger when
 					// we reposition the selection to right at the end of the
@@ -626,12 +621,12 @@ define( [
 					// Not sure what the next event is yet but we need to
 					// ignore it as well, ignoring it prevents the value of
 					// hrefField from being set to the old value.
+
 					that.ignoreNextSelectionChangedEvent = true;
 					range.startContainer = range.endContainer;
 					range.startOffset = range.endOffset;
 					range.select();
-					that.ignoreNextSelectionChangedEvent = true;
-					
+
 					var hrefValue = jQuery( that.hrefField.getInputElem() ).attr( 'value' );
 					
 					if ( hrefValue == that.hrefValue || hrefValue == '' ) {


### PR DESCRIPTION
When typing the URL and then pressing ENTER, the link is created but the
user must click two times for the link properties Tab to open. The
changes in this fix allow to open the link properties by clicking just
once.
