### PR TITLE
Link plugin: click once to open link Tab. 'self' as default target

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -34,4 +34,10 @@ All changes are categorized into one of the following keywords:
               the rows and the columns of the table. This has been fixed so the tooltip does
               disappear. RT#57677
 
+- **BUGFIX**: link plugin: When typing the URL for a link and then pressing Enter,
+              it creates the link but you must click tow times to open the link
+              properties. The fix allows the user to click just once. RT#57711
 
+- **BUGFIX**: link plugin: creating a link and then linking to a page of Content.Node,
+              set the target of the link to 'framename' instead of 'self'. This fix 
+              sets it to 'self'.  RT#57711

--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -303,10 +303,12 @@ define( [
 							'<div class="' + pl.nsClass( 'title-container' ) + '" ><fieldset><legend>' + i18n.t( 'link.title.legend' ) + '</legend><input type="text" class="' + pl.nsClass( 'linkTitle' ) + '" /></fieldset></div>'
 						).content; 
 					 
-					 jQuery( pl.nsSel( 'framename' ) ).live( 'keyup', function () {
+					 jQuery(content).find( pl.nsSel( 'framename' ) ).live( 'keyup', function () {
 						jQuery( that.effective ).attr( 'target', jQuery( this ).val().replace( '\"', '&quot;' ).replace( "'", "&#39;" ) );
 					 } );
-					 
+
+					 jQuery(content).find( pl.nsSel( 'framename' ) ).hide().val( '' );
+
 					 jQuery( pl.nsSel( 'radioTarget' ) ).live( 'change', function () {
 						if ( jQuery( this ).val() == 'framename' ) {
 							jQuery( pl.nsSel( 'framename' ) ).slideDown();
@@ -325,18 +327,18 @@ define( [
 					var that = this;
 					that.effective = effective;
 					if ( jQuery( that.effective ).attr( 'target' ) != null ) {
-						var isFramename = true;
+						var isSelf = true;
 						jQuery( pl.nsSel( 'framename' ) ).hide().val( '' );
 						jQuery( pl.nsSel( 'radioTarget' ) ).each( function () {
 							jQuery( this ).removeAttr('checked');
 							if ( jQuery( this ).val() === jQuery( that.effective ).attr( 'target' ) ) {
-								isFramename = false;
+								isSelf = false;
 								jQuery( this ).attr( 'checked', 'checked' );
 							}
 						} );
-						if ( isFramename ) {
-							jQuery( pl.nsSel( 'radioTarget[value="framename"]' ) ).attr( 'checked', 'checked' );
-							jQuery( pl.nsSel( 'framename' ) )
+						if ( isSelf ) {
+							jQuery( pl.nsSel( 'radioTarget[value="_self"]' ) ).attr( 'checked', 'checked' );
+							jQuery( pl.nsSel( '_self' ) )
 								.val( jQuery( that.effective ).attr( 'target' ) )
 								.show();
 						}
@@ -613,12 +615,7 @@ define( [
 				if (Keys.getToken(event.keyCode) === 'enter') {
 					// Update the selection and place the cursor at the end of the link.
 					var	range = Aloha.Selection.getRangeObject();
-					
-					// workaround to keep the found markup otherwise removelink won't work
-//					var foundMarkup = that.findLinkMarkup( range );
-//					console.dir(foundMarkup);
-//					that.hrefField.setTargetObject(foundMarkup, 'href');
-					
+
 					// We have to ignore the next 2 onselectionchange events.
 					// The first one we need to ignore is the one trigger when
 					// we reposition the selection to right at the end of the
@@ -626,12 +623,12 @@ define( [
 					// Not sure what the next event is yet but we need to
 					// ignore it as well, ignoring it prevents the value of
 					// hrefField from being set to the old value.
+
 					that.ignoreNextSelectionChangedEvent = true;
 					range.startContainer = range.endContainer;
 					range.startOffset = range.endOffset;
 					range.select();
-					that.ignoreNextSelectionChangedEvent = true;
-					
+
 					var hrefValue = jQuery( that.hrefField.getInputElem() ).attr( 'value' );
 					
 					if ( hrefValue == that.hrefValue || hrefValue == '' ) {


### PR DESCRIPTION
When typing the URL and then pressing ENTER, the link is created but the
user must click two times for the link properties Tab to open. The
changes in this fix allow to open the link properties by clicking just
once.

The default target was set to 'framename' instead of 'self'.
