### PR TITLE
Link plugin: click once to open link Tab. 'self' as default target

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -34,4 +34,7 @@ All changes are categorized into one of the following keywords:
               the rows and the columns of the table. This has been fixed so the tooltip does
               disappear. RT#57677
 
+- **BUGFIX**: link plugin: When typing the URL for a link and then pressing Enter,
+              it creates the link but you must click tow times to open the link
+              properties. The fix allows the user to click just once. RT#57711
 

--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -303,9 +303,11 @@ define( [
 							'<div class="' + pl.nsClass( 'title-container' ) + '" ><fieldset><legend>' + i18n.t( 'link.title.legend' ) + '</legend><input type="text" class="' + pl.nsClass( 'linkTitle' ) + '" /></fieldset></div>'
 						).content; 
 					 
-					 jQuery( pl.nsSel( 'framename' ) ).live( 'keyup', function () {
+					 jQuery(pl.nsSel( 'framename' ) ).live( 'keyup', function () {
 						jQuery( that.effective ).attr( 'target', jQuery( this ).val().replace( '\"', '&quot;' ).replace( "'", "&#39;" ) );
 					 } );
+					 
+					 jQuery(content).find(pl.nsSel( 'framename' ) ).hide();
 					 
 					 jQuery( pl.nsSel( 'radioTarget' ) ).live( 'change', function () {
 						if ( jQuery( this ).val() == 'framename' ) {
@@ -324,7 +326,8 @@ define( [
 				onActivate: function ( effective ) {
 					var that = this;
 					that.effective = effective;
-					if ( jQuery( that.effective ).attr( 'target' ) != null ) {
+					if ( jQuery( that.effective ).attr( 'target' ) != null &&
+							jQuery( that.effective ).attr( 'target' ).trim().length > 0) {
 						var isFramename = true;
 						jQuery( pl.nsSel( 'framename' ) ).hide().val( '' );
 						jQuery( pl.nsSel( 'radioTarget' ) ).each( function () {
@@ -613,12 +616,7 @@ define( [
 				if (Keys.getToken(event.keyCode) === 'enter') {
 					// Update the selection and place the cursor at the end of the link.
 					var	range = Aloha.Selection.getRangeObject();
-					
-					// workaround to keep the found markup otherwise removelink won't work
-//					var foundMarkup = that.findLinkMarkup( range );
-//					console.dir(foundMarkup);
-//					that.hrefField.setTargetObject(foundMarkup, 'href');
-					
+
 					// We have to ignore the next 2 onselectionchange events.
 					// The first one we need to ignore is the one trigger when
 					// we reposition the selection to right at the end of the
@@ -626,12 +624,12 @@ define( [
 					// Not sure what the next event is yet but we need to
 					// ignore it as well, ignoring it prevents the value of
 					// hrefField from being set to the old value.
+
 					that.ignoreNextSelectionChangedEvent = true;
 					range.startContainer = range.endContainer;
 					range.startOffset = range.endOffset;
 					range.select();
-					that.ignoreNextSelectionChangedEvent = true;
-					
+
 					var hrefValue = jQuery( that.hrefField.getInputElem() ).attr( 'value' );
 					
 					if ( hrefValue == that.hrefValue || hrefValue == '' ) {
@@ -789,7 +787,6 @@ define( [
 			apiRange.setEnd(range.endContainer, range.endOffset);
 
 			PubSub.pub('aloha.link.insert', {range: apiRange});
-			this.hrefChange();
 		},
 
 		/**


### PR DESCRIPTION
When typing the URL and then pressing ENTER, the link is created but the
user must click two times for the link properties Tab to open. The
changes in this fix allow to open the link properties by clicking just
once.

The default target was set to 'framename' instead of 'self'. With this
fix the default target is set to 'self'.
