### PR TITLE
Click once on a link to open the link properties tab.

### DIFF
--- a/build/hotfix-changelog.md
+++ b/build/hotfix-changelog.md
@@ -16,3 +16,7 @@ All changes are categorized into one of the following keywords:
               the page up and down (with some strange rendering of the cursor).
               This has been fixed now to prevent entering non editable areas with
               the cursor. #RT57706
+              
+- **BUGFIX**: link plugin: When typing the URL for a link and then pressing Enter,
+              it creates the link but you must click tow times to open the link
+              properties. The fix allows the user to click just once. RT#57711

--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -623,15 +623,12 @@ define( [
 					// The first one we need to ignore is the one trigger when
 					// we reposition the selection to right at the end of the
 					// link.
-					// Not sure what the next event is yet but we need to
-					// ignore it as well, ignoring it prevents the value of
-					// hrefField from being set to the old value.
+
 					that.ignoreNextSelectionChangedEvent = true;
 					range.startContainer = range.endContainer;
 					range.startOffset = range.endOffset;
 					range.select();
-					that.ignoreNextSelectionChangedEvent = true;
-					
+
 					var hrefValue = jQuery( that.hrefField.getInputElem() ).attr( 'value' );
 					
 					if ( hrefValue == that.hrefValue || hrefValue == '' ) {


### PR DESCRIPTION
When typing the URL and then pressing ENTER, the link is created but the
user must click two times for the link properties Tab to open. The
changes in this fix allow to open the link properties by clicking just
once.
