### PR TITLE
Scroll to correct place when paste is done

### DIFF
--- a/src/paste.js
+++ b/src/paste.js
@@ -176,11 +176,11 @@ define([
 	 * Scrolls to the range.
 	 */
 	function scrollToRange(doc, range) {
-		var position = Dom.offset(getFirstParentBlockElement(range.startContainer));
+		var position = Ranges.box(range);
 		var win = Dom.windowFromDocument(doc);
 
 		var adjust = (win.innerHeight - (win.innerHeight / 5));
-		win.scrollTo(position.left, position.top - adjust);
+		win.scrollTo(position.left, position.top + win.pageYOffset - adjust);
 	}
 
 	/**


### PR DESCRIPTION
Scroll to content when a paragraph has a huge content, was not correct. It scroll always to the beginning of the content, not to the the last text.
