### PR TITLE
Account for empty or partial Aloha.settings.plugins.list.templates objects

### DIFF
--- a/src/plugins/common/list/lib/list-plugin.js
+++ b/src/plugins/common/list/lib/list-plugin.js
@@ -76,6 +76,13 @@ define([
 	    return str;
 	};
 
+	/**
+	* Shows or hides the ul, ol or dl buttons in Aloha floating menu
+	* if they are configured.
+	* @param Plugin plugin the list plugin 
+	* @param String listtype the type of listbutton to toggle (ul, ol, dl)
+	* @param Boolean show hide or show the button
+	*/
 	function toggleListOption(plugin, listtype, show) {
 		switch (listtype) {
 		case 'ul':


### PR DESCRIPTION
So the user can properly override the standard configuration.
