### PR TITLE
Format style creates a new span when it is inside an editable span.

### DIFF
--- a/build/changelog/entries/2014/02/10011.RT57791.bugfix
+++ b/build/changelog/entries/2014/02/10011.RT57791.bugfix
@@ -1,0 +1,2 @@
+Text-color: a new span is created when setting color inside an editable span.
+When formatting style inside an editable span, the style should not be include in the span style but in a new span.

--- a/src/lib/util/range-context.js
+++ b/src/lib/util/range-context.js
@@ -564,7 +564,7 @@ define([
 	}
 
 	function isStyleWrapperReusable_default(node) {
-		return 'SPAN' === node.nodeName;
+		return 'SPAN' === node.nodeName && !Html.isEditingHost(node);
 	}
 
 	function isStyleWrapperPrunable_default(node) {

--- a/src/test/unit/util/range-context-tests.js
+++ b/src/test/unit/util/range-context-tests.js
@@ -377,4 +377,9 @@ Aloha.require([
 	t('don\'t reuse if there is an obstruction above (&lt;code>)',
 	  '<p>one<span style="font-family: times;"><code>[Some text]</code></span>two</p>',
 	  '<p>one<span style="font-family: times;"><code>{<span style="font-family: arial;">Some text</span>}</code></span>two</p>');
+
+	t('don\'t reuse if it is an editable span',
+		'<p>one<span contenteditable="true" style="font-family: times;">[Some text]</span>two</p>',
+		'<p>one<span contenteditable="true" style="font-family: times;">{<span style="font-family: arial;">Some text</span>}</span>two</p>');
+
 });


### PR DESCRIPTION
When formatting style inside an editable span, the style should not be include in the span style but in a new span.
