### PR TITLE
Align only applies to the selected paragraphs.

### DIFF
--- a/build/changelog/entries/2014/02/10017.RT57797.bugfix
+++ b/build/changelog/entries/2014/02/10017.RT57797.bugfix
@@ -1,4 +1,4 @@
 align-plugin: align only applies to the selected paragraphs.
-When selecting several paragraphs and these paragraphs are wrapped in a block element not editable, the
-align style is set into the block element instead of the paragraphs. With these changes the align style is
-only applied to the selected block elements.
+When selecting several paragraphs and these paragraphs are wrapped in a block element which is not the editing host,
+the align style was set into the block element instead of into the paragraphs. With these changes the align style is
+only applied to the selected paragraphs.

--- a/src/plugins/common/align/lib/align-plugin.js
+++ b/src/plugins/common/align/lib/align-plugin.js
@@ -81,7 +81,8 @@ define([
 				elements.push(node);
 			}
 		});
-		if (elements.length === 0 && selection.length > 0 && Html.isBlock(cac)) {
+
+		if (elements.length === 0 && selection.length > 0 && Html.isBlock(cac) && !DomLegacy.isEditingHost(cac)) {
 			elements.push(cac);
 		}
 		return elements;


### PR DESCRIPTION
When selecting several paragraphs and these paragraphs are wrapped in a non-editable block element, the align style is set into the block element instead of the paragraphs. With these changes the align style is only applied to the selected block elements.
