### PR TITLE
Fix detection of ordered list to trim text before checking with regex.

### DIFF
--- a/build/changelog/entries/2014/03/10020.RT57824.bugfix
+++ b/build/changelog/entries/2014/03/10020.RT57824.bugfix
@@ -1,0 +1,2 @@
+When pasting nested ordered lists from Word, some lists where incorrectly recognized as unordered lists.
+This has been fixed now.

--- a/src/plugins/common/contenthandler/lib/wordcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/wordcontenthandler.js
@@ -215,7 +215,7 @@ define([
 				return false;
 			}
 			// otherwise check for a number, letter or '(' as first character
-			return listSpan.text().match(/^([0-9]{1,3}\.)|([0-9]{1,3}\)|([a-zA-Z]{1,5}\.)|([a-zA-Z]{1,5}\)))$/) ? true : false;
+			return $.trim(listSpan.text()).match(/^([0-9]{1,3}\.)|([0-9]{1,3}\)|([a-zA-Z]{1,5}\.)|([a-zA-Z]{1,5}\)))$/) ? true : false;
 		},
 
 		/**


### PR DESCRIPTION
This fixes some ordered lists to be incorrectly recognized as unordered
lists due to trailing whitespace.
