### PR TITLE
table-plugin: WAI input stays when you click on it.

### DIFF
--- a/build/changelog/entries/2014/02/10018.RT57827.bugfix
+++ b/build/changelog/entries/2014/02/10018.RT57827.bugfix
@@ -1,0 +1,5 @@
+table-plugin: WAI input stays when you click on it.
+
+WAI input disappeared because of a selection issue with mouse-up event. Mouse-up event was stopped
+if a cell is selected. Mouseup event should not be stopped because it is used in the
+jquery.aloha.js file (jquery.aloha.js:207) for initializing the selection.

--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -324,7 +324,6 @@ define([
 			var that = this;
 			jQuery('body').bind('mouseup.cellselection', function(event) {
 				that._endCellSelection();
-				event.stopPropagation();
 			});
 
 			this.tableObj.selection.baseCellPosition = [this._virtualY(), this._virtualX()];


### PR DESCRIPTION
WAI input disappeared because of a selection issue with mouse-up event. Mouse-up event was stopped if a cell is selected. Mouseup event should not be stopped because it is used in the jquery.aloha.js file (jquery.aloha.js:207) for initializing the selection.
