### PR TITLE
table-plugin: row/column floating menu stays when a row/column is selected

### DIFF
--- a/build/changelog/entries/2014/03/10024.rd12385.bugfix
+++ b/build/changelog/entries/2014/03/10024.rd12385.bugfix
@@ -1,0 +1,5 @@
+table-plugin: row/column floating menu stays when a row/column is selected.
+
+Selecting a row/column in a table did throw a javascript exception regarding the selection range (rangy-core issue).
+This error is caught for IE7 and IE8, but not for document mode 7 or 8. Catching the error in case the
+document mode is less or equal to 8 solves the issue.

--- a/src/plugins/common/table/lib/table-plugin-utils.js
+++ b/src/plugins/common/table/lib/table-plugin-utils.js
@@ -530,7 +530,8 @@ define([
 			var anchor = getAnchorCell(selection);
 			if (anchor) {
 				var element = $('>.aloha-table-cell-editable', anchor)[0];
-				if (Browser.ie7 || Browser.ie8) {
+				var doc = anchor.ownerDocument;
+				if (Browser.ie && doc.documentMode <= 8) {
 					try {
 						CopyPaste.selectAllOf(element);
 					} catch (e) {


### PR DESCRIPTION
Selecting a row/column in table did throw a javascript exception regarding the selection range (rangy-core issue). This error is caught for IE7 and IE8, but not for document mode 7 or 8. Catching the error in case the document mode is less or equal than 8 solves the issue.
