### PR TITLE
Copy paste tables from MS Word to IE does not create several tables.

### DIFF
--- a/build/changelog/entries/2014/03/10026.RT57667.bugfix
+++ b/build/changelog/entries/2014/03/10026.RT57667.bugfix
@@ -1,0 +1,8 @@
+Copy paste tables from MS Word to IE does not create several tables.
+
+When copying and pasting tables from Word to IE several tables were created, one table for each row,
+instead of one unique table. This was due to 2 problems: the generic content handler was not set and
+a bug in the pasting code. Generic content handler sanitizes the copied content. The second problem
+is that an element is unwrapped if this is the only element in the paragraph. If the element is a Table
+the unwrap should not be done. For Firefox or Chrome this not happens because the paragraph has always
+more than one element, it contains empty elements.

--- a/src/demo/boilerplate/js/aloha-config.js
+++ b/src/demo/boilerplate/js/aloha-config.js
@@ -204,4 +204,8 @@
 			}
 		}
 	};
+
+	Aloha.settings.contentHandler = {
+		insertHtml: [ 'word', 'generic', 'oembed', 'sanitize' ]
+	};
 } )( window );

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -4504,6 +4504,23 @@ define([
 		}
 	}
 
+	/**
+	 * Node names that can not be unwrapped.
+	 *
+	 * @const
+	 * @type {string[]}
+	 */
+	var NOT_UNWRAPPABLE_NODES = ['TABLE', 'OL', 'UL', 'DL'];
+
+	/**
+	 * Checks if `node` can be unwrapped.
+	 *
+	 * @param  {Element} node
+	 * @return {boolean}
+	 */
+	function isUnwrappable(node) {
+		return NOT_UNWRAPPABLE_NODES.indexOf(node.nodeName) === -1;
+	}
 	//@}
 	///// Assorted block formatting command algorithms /////
 	//@{
@@ -4599,7 +4616,9 @@ define([
 			// now that the parent has only the node as child (because we
 			// removed any existing empty text nodes), we can safely unwrap the
 			// node's contents, and correct the range if necessary
-			if (node.parentNode.childNodes.length == 1) {
+			// if the node is unwrappable (table, lists) the node is not unwrapped
+			// but splitted.
+			if (node.parentNode.childNodes.length == 1 && isUnwrappable(node)) {
 				newStartOffset = range.startOffset;
 				newEndOffset = range.endOffset;
 


### PR DESCRIPTION
When copying and pasting tables from Word to IE several tables were created, one table for each row instead of one unique table. This was due to 2 problems: the generic content handler was not set and a bug in the pasting code. Generic content handler sanitizes the copied content. The second problem is that an element is unwrapped if this is the only element in the paragraph. With this fix if the element is unwrappable (table, tbody, ..) the unwrap is not done. For Firefox or Chrome this not happens because the paragraph has always more than one element because it contains empty elements.
