### PR TITLE
table-plugin: setting a row/column as table header does remove the cells selection

### DIFF
--- a/build/changelog/entries/2014/03/10029.RM13393.bugfix
+++ b/build/changelog/entries/2014/03/10029.RM13393.bugfix
@@ -1,0 +1,6 @@
+table-plugin: setting a row/column as table header does remove the cells selection.
+
+When setting a row/column as table header the cell selection was not removed. Setting a row/column as
+table header removes the selected row/column and replaces it by a new one. The
+problem was that the 'unselect' function was called for the removed row/column instead of
+for the newly inserted row/column. Updating the selection to the new row/column fixes the issue.

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -262,7 +262,6 @@ define([
 			j,
 			allHeaders = table.selection.isHeader(),
 			domCell, // representation of the cell in the dom
-			tableCell, // table-cell object
 			bufferCell; // temporary buffer
 
 		for (i = 0; i < table.selection.selectedCells.length; i++) {
@@ -808,8 +807,9 @@ define([
 
 					toggleHeaderStatus(that.activeTable, 'col');
 
-					that.activeTable.selection.unselectCells();
+					// Update selection to the new row
 					that.activeTable.selection.selectRows(that.activeTable.selection.selectedRowIdxs);
+					that.activeTable.selection.unselectCells();
 				}
 			}
 		});
@@ -920,8 +920,9 @@ define([
 
 					toggleHeaderStatus(that.activeTable, 'row');
 
-					that.activeTable.selection.unselectCells();
+					// Update selection to the new column
 					that.activeTable.selection.selectColumns(that.activeTable.selection.selectedColumnIdxs);
+					that.activeTable.selection.unselectCells();
 				}
 			}
 		});


### PR DESCRIPTION
When setting a row/column as table header the cell selection was not removed. Setting a row/column as table header removes the selected row/column and replaces it by a new one. The problem was that the 'unselect' function was called for the removed row/column instead of for the newly inserted row/column. Updating the selection to the new row/column fixes the issue.
