### PR TITLE
table-plugin: inserting new row/column keeps the table header.

### DIFF
--- a/build/changelog/entries/2014/03/10048.RM13394.bugfix
+++ b/build/changelog/entries/2014/03/10048.RM13394.bugfix
@@ -1,0 +1,6 @@
+table-plugin: inserting new row/column keeps the headers.
+
+If a header was set in a table and then a new row/column was inserted,
+the newly inserted row/column had not header cell, it looked like the
+table header was broken in two parts. With this fix the new
+inserted row/column keeps the header.

--- a/src/plugins/common/table/lib/table-plugin-utils.js
+++ b/src/plugins/common/table/lib/table-plugin-utils.js
@@ -530,7 +530,7 @@ define([
 			var anchor = getAnchorCell(selection);
 			if (anchor) {
 				var element = $('>.aloha-table-cell-editable', anchor)[0];
-				if (Browser.ie && anchor.ownerDocument.documentMode <= 8) {
+				if (Browser.ie) {
 					try {
 						CopyPaste.selectAllOf(element);
 					} catch (e) {

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -1454,8 +1454,12 @@ define([
 					var cellInfo = newRow[i];
 					if (Utils.containsDomCell(cellInfo)) {
 						var colspan = cellInfo.colspan;
+						var newCellNode = '<td>&nbsp;</td>';
+						if (cellInfo.cell.nodeName === 'TH') {
+							newCellNode = '<th>&nbsp;</th>';
+						}
 						while (colspan--) {
-							$insertionRow.append(this.newActiveCell().obj);
+							$insertionRow.append(this.newActiveCell(newCellNode).obj);
 						}
 					} else {
 						jQuery( cellInfo.cell ).attr('rowspan', cellInfo.rowspan + 1);
@@ -1510,12 +1514,12 @@ define([
 	 */
 	Table.prototype.addColumns = function( position ) {
 		var
-			that = this,
 			emptyCell = jQuery( '<td>' ),
+			emptyHeaderCell = jQuery( '<th>' ),
+			leftCell,
 		    rows = this.getRows(),
 			cell,
 			currentColIdx,
-			columnsToSelect = [],
 			selectedColumnIdxs = this.selection.selectedColumnIdxs;
 
 		if ( 0 === selectedColumnIdxs.length ) {
@@ -1548,7 +1552,13 @@ define([
 
 		for ( var i = 0; i < rows.length; i++ ) {
 			// prepare the cell to be inserted
-			cell = emptyCell.clone();
+			leftCell = Utils.leftDomCell( grid, i, currentColIdx );
+
+			if (leftCell && leftCell.nodeName === 'TH') {
+				cell = emptyHeaderCell.clone();
+			} else {
+				cell = emptyCell.clone();
+			}
 			cell.html( '\u00a0' );
 
 			// on first row correct the position of the selected columns
@@ -1561,8 +1571,7 @@ define([
 				cell = cellObj.obj;
 			}
 
-			var leftCell = Utils.leftDomCell( grid, i, currentColIdx );
-			if ( null == leftCell ) {
+			if (!leftCell) {
 				jQuery( rows[i] ).prepend( cell );
 			} else {
 				if ( 'left' === position && Utils.containsDomCell( grid[ i ][ currentColIdx ] ) ) {


### PR DESCRIPTION
If a header was set in a table and then a new row/column was inserted, the newly inserted row/column had no header cell, it looked like the table header was broken in 2. With this fix the new inserted row/column has the header cell.
