### PR TITLE
IE default drag and drop behavior is stopped when dragging and dropping

### DIFF
--- a/build/changelog/entries/2014/03/10049.RT57629.bugfix
+++ b/build/changelog/entries/2014/03/10049.RT57629.bugfix
@@ -1,0 +1,8 @@
+IE default drag and drop behavior is stopped when dragging and dropping block elements.
+
+In some cases the default IE drag and drop behavior was not stopped for block elements,
+which end up with pasted elements that could not be removed. The root of
+the problem was a Javascript Error (rangy-core) when dragging the element. This error
+was thrown due to a bug in the IE selection. With this fix the IE default drag and drop 
+behavior is stopped and the Javascript Error is catch so the execution of the program 
+can continue.

--- a/src/lib/util/range.js
+++ b/src/lib/util/range.js
@@ -349,7 +349,16 @@ define([
 
 			// update the selection
 			sel = rangy.getSelection();
-			sel.setSingleRange(range);
+			// Selection type 'Control' (elements selected), 'Text' (text selected), 'None' (nothing selected) 
+			// (http://help.dottoro.com/ljitmswc.php)
+			// If the selection is 'Text' or 'Control' and the range is collapsed then there is nothing selected, and 
+			// this can produce a Javascript Error only in IE. (Reproducible: Just by dragging and drop block elements)
+			// catching the exception so the execution can continue
+			try {
+				sel.setSingleRange(range);
+			} catch (e) {
+				console.warn(e);
+			}
 		},
 
 		/**

--- a/src/plugins/common/block/lib/dragbehavior.js
+++ b/src/plugins/common/block/lib/dragbehavior.js
@@ -163,11 +163,18 @@ define([
 				 * before dragging is started.
 				 */
 				restore: function restoreSelection() {
+					if (!range) {
+						return;
+					}
 					var editable = CopyPaste.getEditableAt(range);
 					if (editable) {
 						editable.obj.focus();
 					}
-					CopyPaste.setSelectionAt(range);
+					try {
+						CopyPaste.setSelectionAt(range);
+					} catch (e) {
+						Console.warn(e);
+					}
 					window.scrollTo(x, y);
 				}
 			}
@@ -191,7 +198,15 @@ define([
 
 		// Prevent the prevention of drag inside a cell
 		element.ondragstart = function (e) {
-			e.stopPropagation();
+			if (e) {
+				if (typeof e.stopPropagation === 'function') {
+					e.stopPropagation();
+				} else {
+					e.cancelBubble = true;
+				}
+			} else {
+				window.event.cancelBubble = true;
+			}
 		};
 
 		$handle


### PR DESCRIPTION
In some cases the default IE drag and drop behavior was not stopped for
blocks, so dragging and dropping blocks messed up the content. The root
of the problem was a Javascript Error (rangy-core) when dragging the
element. This error was thrown due to a bug in the IE selection. With
this fix the IE default drag and drop behavior is stopped and the
Javascript Error is not thrown.
