### PR TITLE
Enable formatlesspaste plugin to remove empty tags RT#57942

### DIFF
--- a/build/changelog/entries/2014/03/10054.RT57942.bugfix
+++ b/build/changelog/entries/2014/03/10054.RT57942.bugfix
@@ -1,0 +1,1 @@
+The extra/formatlesspaste plugin now can remove tags that don't contain text (e.g. img)

--- a/src/plugins/extra/formatlesspaste/lib/formatlesshandler.js
+++ b/src/plugins/extra/formatlesspaste/lib/formatlesshandler.js
@@ -43,7 +43,11 @@ define([
 	 */
 	function removeFormatting($content, toStrip) {
 		$content.find(toStrip.join(',')).each(function () {
-			$(this).contents().unwrap();
+			if ($(this).contents().length === 0) {
+				$(this).remove();
+			} else {
+				$(this).contents().unwrap();
+			}
 		});
 	}
 


### PR DESCRIPTION
-  obey coding guidelines: check
-  write JSLint compliant code: doesn't work for my ide
-  write JSDoc for every method you touched during your implementation: check
-  write a human-readable :) Changelog entry that describes your change: check
-  add a qunit test (if it makes sense) and/or document the steps to manually test it (in a separate guides page): don't know if it makes sense
-  test your changes in Internet Explorer 7, 8, 9 and the latest Firefox and latest Chrome: works for chrome, only using jQuery
-  document your changes in a guides page: it's only a small bugfix
-  include this list in a your pull request: check
