### PR TITLE
Fix checking for allowed tag hierarchy for tables. The way, the check is

### DIFF
--- a/build/changelog/entries/2014/03/10030.RT57823.bugfix
+++ b/build/changelog/entries/2014/03/10030.RT57823.bugfix
@@ -1,0 +1,3 @@
+It is now possible to insert tables into editables that are contained in (not editable) tables themselves.
+Nesting editable tables into editable tables still does not work. The table plugin will show the insert button,
+but will prevent nesting with a message to the user.

--- a/src/lib/aloha/selection.js
+++ b/src/lib/aloha/selection.js
@@ -361,7 +361,6 @@ define([
 				'ul': this.tagHierarchy.ul,
 				'ol': this.tagHierarchy.ol,
 				'li': this.tagHierarchy.li,
-				'td': this.tagHierarchy.li,
 				'div': this.tagHierarchy.div,
 				'h1': this.tagHierarchy.h1,
 				'h2': this.tagHierarchy.h1,
@@ -369,7 +368,14 @@ define([
 				'h4': this.tagHierarchy.h1,
 				'h5': this.tagHierarchy.h1,
 				'h6': this.tagHierarchy.h1,
-				'table': this.tagHierarchy.table
+				// for tables (and all related tags) we set the hierarchy to div
+				// this enables to add anything into tables. We also need to set this
+				// for tr, td and th, because the check in canTag1WrapTag2 does not check
+				// transitively
+				'table': this.tagHierarchy.div,
+				'tr': this.tagHierarchy.div,
+				'th': this.tagHierarchy.div,
+				'td': this.tagHierarchy.div
 			};
 
 			// When applying this elements to selection they will replace the assigned elements


### PR DESCRIPTION
currently done (not transitive), the tag hierarchy for table related tags
(td, th, tr) has to be set to 'div' to enable inserting tables into
editables that are themselves contained in non-editable tables.
