### PR TITLE
Function 'indexOf' is not supported in IE9 documentMode 7.

### DIFF
--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -4519,7 +4519,7 @@ define([
 	 * @return {boolean}
 	 */
 	function isUnwrappable(node) {
-		return NOT_UNWRAPPABLE_NODES.indexOf(node.nodeName) === -1;
+		return jQuery.inArray(node.nodeName, NOT_UNWRAPPABLE_NODES) === -1;
 	}
 	//@}
 	///// Assorted block formatting command algorithms /////


### PR DESCRIPTION
IndexOf is not supported by documentMode 7, so function 'jQuery.inArray' is used instead.
