### PR TITLE
IE: Right click on selected content does not remove the selection.

### DIFF
--- a/build/changelog/entries/2014/03/10050.RT53267.bugfix
+++ b/build/changelog/entries/2014/03/10050.RT53267.bugfix
@@ -1,0 +1,6 @@
+Right clicking on selected content should not remove the selection in IE
+
+The problem was that 'beforepaste' event was thrown when right clicking. The 'beforepaste' event was
+used to copy/paste content for IE. With this fix the 'beforepaste' event is not necessary any more, the
+whole copy/paste process is done in the 'paste' event. This solution is only for IE8 and below. For
+other IE versions (9 and above) the event 'beforepaste' is still needed.


### PR DESCRIPTION
The problem was that 'beforepaste' event was thrown when right clicking. The 'beforepaste' event was used to copy/paste content for IE. With this fix the 'beforepaste' event is not necessary any more, the whole copy/paste process is done in the 'paste' event. This solution is only for IE8 and below. For other IE versions (9 and above) the event 'beforepaste' is still needed.
