### PR TITLE
Update port-helper-attribute-field.js

### DIFF
--- a/src/plugins/common/ui/lib/port-helper-attribute-field.js
+++ b/src/plugins/common/ui/lib/port-helper-attribute-field.js
@@ -84,6 +84,9 @@ define([
 		if (props.width) {
 			element.width(props.width);
 		}
+		if (props.placeholder) {
+			element.attr('placeholder', props.placeholder);
+		}
 
 		component = Ui.adopt(props.name, Component, {
 			scope: props.scope,


### PR DESCRIPTION
Allow the placeholder attribute in the AttributeField class. This is for adding the Placeholder to the table summary text field in the Aloha toolbar. 
