### PR TITLE
Fix forEach typo

### DIFF
--- a/src/arrays.js
+++ b/src/arrays.js
@@ -138,11 +138,9 @@ define(['functions'], function Arrays(Fn) {
 	 * @return {Array.<*>}
 	 */
 	function mapcat(xs, fn) {
-		var result = [];
-		Array.prototype.forEach.call(xs, function (x) {
-			result = result.concat(fn(x));
-		});
-		return result;
+		return xs.reduce(function(result, x) {
+			return result.concat(fn(x));
+		}, []);
 	}
 
 	/**


### PR DESCRIPTION
This one broke sanbox and crazy-slots, introduced in [this commit](https://github.com/alohaeditor/Aloha-Editor/commit/400e22e0bd558ccdf53d35ba84d84749685a71d2#diff-c3ba2f10bd605d37093f207c79021c5bR142), @deliminator please review if this is what you meant.
