### PR TITLE
Added check for heading hierarchies

### DIFF
--- a/build/changelog/entries/2014/04/10062.enhancement
+++ b/build/changelog/entries/2014/04/10062.enhancement
@@ -1,0 +1,4 @@
+format-plugin: Check the hierarchy of headings
+
+Check the hierarchy of all headings in an editable. If the hierarchy is violated, a class "aloha-heading-hierarchy-violated" is added to the heading. 
+It is also checked if the hierarchy of a heading is lower than the highest allowed hierarchy in the configuration.

--- a/doc/guides/source/plugin_format.textile
+++ b/doc/guides/source/plugin_format.textile
@@ -19,13 +19,25 @@ You can change the layout each time or remove a formatting via clicking the remo
 
 Removing a format will unwrap the contents from the corresponding formatting tag. If you want to ensure that contents are within paragraphs all the time, use the "common/autoparagraph plugin":plugin_autoparagraph.html. Removing a format will also trigger a "smart-content-changed event":events.html#aloha-smart-content-changed-event.
 
+h5. Heading Hierarchy Check
+
+If enabled in the configuration, the hierarchy of headings will be checked and a class "aloha-heading-hierarchy-violated" will be added, if the hierarchy is violated. The highlighting itself must be implemented in the css code.
+If a heading is violating the hierarchy, then the following heading will be checked against the last correct heading.
+The hierarchy is violated, if a heading is more than one hierarchy lower than the previous heading.
+
+It is also checked, if the hierarchy is higher than the highest hierarchy found in the plugin configuration. The purpose of this is to tell the editor, that a 'h1' should not be used in this editable.
+
+For example: if the plugin configuration @config: []@ contains the possible headings: @'h2', 'h3', 'h4', 'h5', 'h6'@, then all occurences of @<h1>@ will be marked like this: @<h1 class='aloha-heading-hierarchy-violated'>@.
+
+This feature is turned on with @'checkHeadingHierarchy: true'@ in the format plugin configuration.
+
 h5. Remove formatting in lists
 
 If you remove formatting on unordered-, ordered- or definition lists and your selection doesn't span more than one individual list, list items will be taken out of the list. If only part of one list item is selected, then the item won't be taken out of the list. In that case only the text formats will be removed.
 
 h5. Tables
 
-Tables won't be deconstructed if you press "remove fromatting" on them, only text formats will be removed.
+Tables won't be deconstructed if you press "remove formatting" on them, only text formats will be removed.
 
  
 h4. Bold and Italic
@@ -90,7 +102,11 @@ Aloha.settings.plugins.format = {
     'sup', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre', 'quote', 'blockquote', 
     'section', 'article', 'aside', 'header', 'footer', 'address', 'main', 'hr', 'figure', 
     'figcaption', 'div', 'small', 'cite', 'dfn', 'abbr', 'data', 'time', 'var', 'samp', 
-    'kbd', 'mark', 'span', 'wbr', 'ins' ]
+    'kbd', 'mark', 'span', 'wbr', 'ins' ],
+	// if set true, a class 'aloha-heading-hierarchy-violated' will be added
+	// to headings that violate the hierarchy, or headings, that are not contained
+	// in config
+	checkHeadingHierarchy: true
 };
 </javascript>
 

--- a/src/demo/dev-headings/index.css
+++ b/src/demo/dev-headings/index.css
@@ -1,0 +1,42 @@
+body {
+  font-family: sans-serif;
+  background-image: url("../common/background.png");
+}
+
+p {
+	margin-bottom: 10px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: sans-serif;
+  color: #1c94c4;
+  border-bottom:1px solid #AAAAAA;
+  padding-bottom:0.17em;
+  padding-top:0.5em;
+}
+
+.aloha-heading-hierarchy-violated {
+  background-color:red;
+}
+
+h1 { font-size: 188%; }
+h2 { font-size: 150%; }
+h3 { font-size: 132%; }
+h4 { font-size: 116%; }
+h5 { font-size: 100%; }
+h6 { font-size: 80%;  }
+
+#main {
+  width: 50%;
+  position: absolute;
+  top: 10%;
+  left: 25%;
+  padding: 30px;
+  background-color: white;
+  border-radius: 10px;
+  color: #444444;
+  -moz-border-radius: 10px;
+  box-shadow: 5px 5px rgba(0,0,0,0.3);
+  -webkit-box-shadow: 5px 5px rgba(0,0,0,0.3);
+  -moz-box-shadow: 5px 5px rgba(0,0,0,0.3);
+}

--- a/src/demo/dev-headings/index.html
+++ b/src/demo/dev-headings/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<title>Heading hierarchy checking</title>
+	<link rel="stylesheet" href="index.css" type="text/css">
+	<link rel="stylesheet" href="../../css/aloha.css" type="text/css">
+	<script src="../../lib/require.js"></script>
+	<script src="../../lib/vendor/jquery-1.7.2.js"></script>
+	<script src="../../lib/aloha.js" data-aloha-plugins="common/ui,common/format,common/highlighteditables,common/link"></script>
+</head>
+<body>
+<div id="main">
+	
+	<div id="content">
+		<p>This is a test page for the "check headings hierarchy" feature of the format plugin. <br>
+			See the guide for the <a href="http://aloha-editor.org/guides/plugin_format.html" hreflang="">format plugin</a> for a description.
+			Look into the html and css source for using the feature.
+		</p>
+		<h1>not in config heading one </h1><br>
+		<p>(Tip: see the config in the html source)</p><br>
+		<h2>very correct heading two</h2><br>
+		<h6>super wrong heading six</h6><br>
+		<h3>correct heading three</h3><br>
+		<h4>great heading four</h4><br>
+		<h2>good heading two</h2><br>
+		<h4>stupid heading four</h4><br>
+		<h5>still stupid five</h5></br>
+		<h3>cool heading three</h3><br>
+	</div>
+	
+	<p>Tip: the markup is only visible in the editor. Feel free to call Aloha.getEditableById("content").getContents(); in your JavaScript console.</p>
+
+</div>
+<script type="text/javascript">
+			Aloha.settings = {
+				plugins: {
+					format: {
+						// all elements with no specific configuration get this configuration
+						// Note that there is no 'h1' in there, so 'h1' violates the hierarchy check
+						config: [ 'b', 'i', 'sub', 'sup', 'p', 'h2', 'h3', 'h4', 'h5', 'h6', 'removeFormat'],
+						editables: {
+							// no formatting allowed for title
+							'#title': [],
+							// just bold and italic for the teaser
+							'#teaser': [ 'b', 'i' ]
+						},
+						//enable the heading hierarchy check
+						checkHeadingHierarchy: true
+					}
+				}
+			}
+			Aloha.ready( function() {
+				Aloha.jQuery('#content').aloha();
+			});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Check the hierarchy of all headlines in an editable. If the hierarchy is violated a class "heading-hierarchy-violated" is added to the heading. It is also checked if the hierarchy of a heading is lower or equal than the highest allowed hierarchy in the configuration.
