### PR TITLE
Fix Maps.extend (discussed in #1138)

### DIFF
--- a/src/maps.js
+++ b/src/maps.js
@@ -120,7 +120,7 @@ define(['arrays', 'assert'], function Maps(Arrays, Assert) {
 
 	function extend(dest) {
 		var i;
-		for (i = 0; i < arguments.length; i++) {
+		for (i = 1; i < arguments.length; i++) {
 			var src = arguments[i];
 			if (src) {
 				forEach(src, function (value, key) {

--- a/tests/maps-tests.js
+++ b/tests/maps-tests.js
@@ -83,6 +83,17 @@
 		equal(maps.isMap(document.createTextNode("xx")), false);
 	});
 
+	test('extend', function () {
+		tested.push('extend');
+		var map = {
+			one: 1
+		}
+		maps.extend(map, {two: 2}, {three: 3});
+		equal(map.one,   1);
+		equal(map.two,   2);
+		equal(map.three, 3);
+	});
+
 	//testCoverage(test, tested, maps);
 
 }(window.aloha));


### PR DESCRIPTION
There is no need to iterate over the object we're extending. This caused the following error in FF:

> TypeError: CSS2Properties doesn't have an indexed property setter. maps.js:127
