### PR TITLE
VideoBlock Plugin

### DIFF
--- a/doc/guides/source/plugin_videoblock.textile
+++ b/doc/guides/source/plugin_videoblock.textile
@@ -1,0 +1,54 @@
+h2. VideoBlock Plugin
+
+The VideoBlock Plugin allows you to paste a YouTube URL into the active editable and it will be replaced by the appropriate iframe embed code.
+
+endprologue.
+
+NOTE: Inserted videos can not be played while editing, because you wouldn't be able to interact with the block if all clicks get sent through to the iframe content.
+
+h3. Functional Description
+
+Move the cursor to your desired position and paste a YouTube URL copied from your browser's address bar (e.g. http://www.youtube.com/watch?v=2ot_katYYiU). The plugin will immediately change the URL to YouTube's embed code and the video will be displayed.
+Now you can resize the video by dragging on the edge with your mouse.
+
+When clicking on a video block a separate toolbar tab will be displayed where you can paste a different URL or delete the whole block by clicking the remove button.
+
+h3. Configuration settings
+
+Add the "video" content handler to the settings array for "insertHtml" (see example below), to activate the conversion of pasted URLs into YouTube embed code. The video tab in the toolbar is activated by adding a new element to the "toolbar.tabs" array (see below).
+The plugin's default settings can be overwritten here as well. Height and width set the initial size of inserted videos, embedUrl configures the desired HTTP protocol (SSL is default) and URL schema ("youtube.com/embed/" is default and should be used to avoid cross-domain problems).
+
+<javascript>
+	Aloha.settings = {
+    	contentHandler: {
+    		insertHtml: [ 'word', 'generic', 'oembed', 'sanitize', 'video' ]
+    	},
+	    toolbar: {
+            tabs: [
+    	        {
+    	            label: 'Video',
+    				showOn: {scope: 'Aloha.Block.VideoBlock'},
+    	            components: [
+    	                [ 'video-url', 'remove-video' ]
+    	            ]
+    	        }
+    		]
+	        
+	    },
+		plugins: {
+            videoblock: {
+    			'width': '800px',
+    			'height': '600px',
+    			'embedUrl': 'https://youtube.com/embed/'
+		    }
+        }
+	};
+</javascript>
+
+h3. Components
+
+The VideoBlock Plugin provides three components
+
+* videoblock-plugin.js - The plugin itself
+* block.js - Custom block definition for YouTube videos
+* content-handler.js - Content handler for converting pasted URLs into video blocks

--- a/doc/guides/source/plugins.textile
+++ b/doc/guides/source/plugins.textile
@@ -103,7 +103,7 @@ Plugins in the @extra@ directory:
 * "extra/vie":plugin_vie.html - integrates VIE.js into Aloha Editor
 * "extra/wai-lang":plugin_wai-lang.html - annotate parts of the content with @lang@ attributes
 * "extra/zemanta°":plugin_zemanta.html - integrates Zemanta into Aloha Editor
-
+* "extra/videoblock":plugin_videoblock.html - allwos for pasting of YouTube links which will then be converted to actual video embed code
 
 Community Plugins:
 * "colorselector":https://github.com/deliminator/Aloha-Plugin-Colorselector - add font color or background color

--- a/src/plugins/extra/videoblock/lib/block.js
+++ b/src/plugins/extra/videoblock/lib/block.js
@@ -1,0 +1,127 @@
+/* block.js is part of Aloha Editor project http://aloha-editor.org
+ *
+ * Aloha Editor is a WYSIWYG HTML5 inline editing library and editor.
+ * Copyright (c) 2010-2014 Gentics Software GmbH, Vienna, Austria.
+ * Contributors http://aloha-editor.org/contribution.php
+ *
+ * Aloha Editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or any later version.
+ *
+ * Aloha Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * As an additional permission to the GNU GPL version 2, you may distribute
+ * non-source (e.g., minimized or compacted) forms of the Aloha-Editor
+ * source code without the copy of the GNU GPL normally required,
+ * provided you include this license notice and a URL through which
+ * recipients can access the Corresponding Source.
+ */
+define([
+	'jquery',
+	'block/block',
+	'block/blockmanager',
+	'jqueryui'
+], function (
+	$,
+	Block,
+	BlockManager
+) {
+	'use strict';
+
+	/**
+	 * Aloha Video Block
+	 * Currently supports YouTube videos, can be easily extended to
+	 * other video sites with the help of content-handler.js
+	 */
+	var VideoBlock = Block.AbstractBlock.extend({
+		/**
+		 * Title for reference
+		 */
+		title: 'Video Block',
+		
+		/**
+		 * Default settings
+		 */
+		settings: {
+			'width': '640px',
+			'height': '360px',
+			'embedUrl': 'https://youtube.com/embed/'
+		},
+
+		/**
+		 * Block initalization
+		 * Creates YouTube iframe and overlay div (so clicking on video interacts
+		 * with Block an not with iframe content)
+		 * @param DOM $element where elements will be inserted to
+		 * @param funciton postProcessFn Aloha Block callback function
+		 */
+		init: function ($element, postProcessFn) {
+
+			// Default settings can be overwritten via Aloha.settings.plugins.videoblock
+			if (Aloha.settings.plugins && Aloha.settings.plugins.videoblock) {
+				this.settings = Aloha.settings.plugins.videoblock;
+			}
+
+			// Insert YouTube iframe into wrapping div
+			$element.css({'width': this.settings.width, 'height': this.settings.height})
+				.append('<iframe width="100%" height="100%" src="' + this.settings.embedUrl
+					+ $element.data('video-id')
+					+ '" frameborder="0" allowfullscreen></iframe>');
+
+			// Insert semi-transparent overlay div so clicks don't get
+			// passed through to video in iframe.
+			$element.append('<div class="video-helper-overlay"></div>');
+			$('.video-helper-overlay', $element).css({
+				'width': '100%',
+				'height': '100%',
+				'position': 'absolute',
+				'top': 0,
+				'left': 0,
+				'display': 'block',
+				'background': '#b0b0b0',
+			    '-ms-filter': 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)',
+			    'filter': 'alpha(opacity=50)',
+			    '-moz-opacity': '0.5',
+			    '-khtml-opacity': '0.5',
+			    'opacity': '0.5'
+			});
+
+			// Use jQuery UI to make video resizable
+			$element.resizable({
+				aspectRatio: true,
+				resize: function (event, ui) {
+					ui.element.css({
+						'position': 'relative',
+						'top': 0,
+						'left': 0
+					});
+				}
+			});
+
+			postProcessFn();
+		},
+
+		/**
+		 * Aloha Block update function must be implemented.
+		 * Receives passed callback function.
+		 * @param funciton postProcessFn Aloha Block callback function
+		 */
+		update: function ($element, postProcessFn) {
+			postProcessFn();
+		}
+
+	});
+
+	// Make block type automatically available to videoblock-plugin
+	BlockManager.registerBlockType('VideoBlock', VideoBlock);
+
+	return VideoBlock;
+});

--- a/src/plugins/extra/videoblock/lib/content-handler.js
+++ b/src/plugins/extra/videoblock/lib/content-handler.js
@@ -1,0 +1,68 @@
+/* content-handler.js is part of Aloha Editor project http://aloha-editor.org
+ *
+ * Aloha Editor is a WYSIWYG HTML5 inline editing library and editor.
+ * Copyright (c) 2010-2014 Gentics Software GmbH, Vienna, Austria.
+ * Contributors http://aloha-editor.org/contribution.php
+ *
+ * Aloha Editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or any later version.
+ *
+ * Aloha Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * As an additional permission to the GNU GPL version 2, you may distribute
+ * non-source (e.g., minimized or compacted) forms of the Aloha-Editor
+ * source code without the copy of the GNU GPL normally required,
+ * provided you include this license notice and a URL through which
+ * recipients can access the Corresponding Source.
+ */
+define([
+	'aloha/contenthandlermanager'
+], function (
+	Manager
+) {
+    'use strict';
+
+	var handler = Manager.createHandler({
+
+		/**
+		 * Extracts YouTube video ID for later insertion into iframe embed code
+		 *
+		 * @param String url The pasted video URL
+		 * @return String or false
+		 */
+		extractVideoId: function (url) {
+			var videoid = url.match(/(?:https?:\/{2})?(?:w{3}\.)?youtu(?:be)?\.(?:com|be)(?:\/watch\?v=|\/)([^\s&]+)/);
+			if(videoid === null) {
+			   return false;
+			}
+			return videoid[1];
+		},
+
+
+		/**
+		 * Construct wrapping DOM element for block
+		 * @param String content the pasted video URL
+		 */
+        handleContent: function (content) {
+			var videoid = this.extractVideoId(content);
+			if (!videoid){
+				return content;
+			}
+            return'<div class="aloha-video-block aloha" data-aloha-block-type="VideoBlock" data-video-id="' + videoid + '"></div>';
+        }
+    });
+
+	// Make content handler automatically available to videoblock-plugin
+	Manager.register('video', handler);
+
+	return handler;
+});

--- a/src/plugins/extra/videoblock/lib/videoblock-plugin.js
+++ b/src/plugins/extra/videoblock/lib/videoblock-plugin.js
@@ -1,0 +1,173 @@
+/* videoblock-plugin.js is part of Aloha Editor project http://aloha-editor.org
+ *
+ * Aloha Editor is a WYSIWYG HTML5 inline editing library and editor.
+ * Copyright (c) 2010-2014 Gentics Software GmbH, Vienna, Austria.
+ * Contributors http://aloha-editor.org/contribution.php
+ *
+ * Aloha Editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or any later version.
+ *
+ * Aloha Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * As an additional permission to the GNU GPL version 2, you may distribute
+ * non-source (e.g., minimized or compacted) forms of the Aloha-Editor
+ * source code without the copy of the GNU GPL normally required,
+ * provided you include this license notice and a URL through which
+ * recipients can access the Corresponding Source.
+ */
+define([
+	'jquery',
+	'aloha/core',
+	'aloha/plugin',
+	'i18n!videoblock/nls/i18n',
+	'i18n!aloha/nls/i18n',
+	'block/blockmanager',
+	'ui/ui',
+	'ui/button',
+	'ui/port-helper-attribute-field',
+	'videoblock/block',
+	'videoblock/content-handler'
+], function (
+	$,
+	Aloha,
+	Plugin,
+	i18n,
+	i18nCore,
+	BlockManager,
+	Ui,
+	Button,
+	AttributeField,
+	VideoBlock,
+	ContentHandler
+) {
+	'use strict';
+
+	/**
+	* Curerntly selected block
+	*/
+	var selectedBlock;
+
+	/**
+	 * Checks to see if video blocks in current editable are already initialized
+	 *
+	 * @param Dom element jQuery element with class 'aloha-video-block'
+	 * @return Boolean
+	 */
+	function isInitialized(element) {
+		return $(element).hasClass('aloha-block');
+	}
+
+	/**
+	 * Removes selected VideoBlock on toolbar button click
+	 */
+	function removeVideoBlock() {
+		selectedBlock.$element[0].remove();
+	}
+
+	return Plugin.create('videoblock', {
+
+		/**
+		 * Default settings
+		 */
+		settings: {
+			'width': '640px',
+			'height': '360px',
+			'embedUrl': 'https://youtube.com/embed/'
+		},
+
+		/**
+		* Reference to input field in video tab
+		*/
+		hrefField: null,
+
+		/**
+		 * Add URL-field and remove-button to video tab in Aloha floating menu
+		 */
+		createToolbarTab: function () {
+			this.hrefField = new AttributeField({
+				name: 'video-url',
+				width: 320,
+				valueField: 'url',
+				label: i18n.t("tab.video.label")
+			});
+
+			var removeVideoButton = Ui.adopt("remove-video", Button, {
+				tooltip: i18n.t("button.removevideo.tooltip"),
+				icon: "aloha-icon aloha-icon-unlink",
+				click: function() {
+					removeVideoBlock();
+				}
+			});
+		},
+
+		/**
+		 * Set input field in video tab to video URL
+		 */
+		setHrefField: function () {
+			if(typeof selectedBlock !== 'undefined'){
+				$(this.hrefField.getInputElem()).val('http://youtube.com/watch?v='
+					+ selectedBlock.$element.data('video-id'));
+			}
+		},
+
+		/**
+		 * Get on changed video URL from input in toolbar
+		 * and apply YouTube video id to "src" attribute of iframe.
+		 */
+		hrefChange: function () {
+			var videoid = ContentHandler.extractVideoId($(this.hrefField.getInputElem()).val());
+			selectedBlock.$element.find('iframe').attr('src', this.settings.embedUrl + videoid);
+			selectedBlock.$element.data('video-id', videoid);
+		},
+
+		/**
+		* Initialize plugin
+		*/
+		init: function () {
+			var that = this;
+			
+			// Default settings can be overwritten via Aloha.settings.plugins.videoblock
+			if (Aloha.settings.plugins && Aloha.settings.plugins.videoblock) {
+				this.settings = Aloha.settings.plugins.videoblock;
+			}
+			
+			this.createToolbarTab();
+
+			/**
+			 * Event listener for toolbar tab input field URL changes
+			 */
+			this.hrefField.addListener('keyup', function (event) {
+				that.hrefChange();
+			});
+
+			/**
+			 * Event listener for block selection,
+			 * to change toolbar tab input field value
+			 */
+			BlockManager.bind('block-selection-change', function (blocks){
+				selectedBlock = blocks[0];
+				that.setHrefField();
+			});
+
+			/**
+			 * Event listener for editable to initialize video blocks
+			 */
+			Aloha.bind('aloha-smart-content-changed', function (event, data) {
+				data.editable.obj.find('.aloha-video-block').each(function () {
+					if (!isInitialized(this)){
+						$(this).alohaBlock();
+					}
+				});
+			});
+		}
+	});
+});

--- a/src/plugins/extra/videoblock/nls/ca/i18n.js
+++ b/src/plugins/extra/videoblock/nls/ca/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "",
+	"button.removevideo.tooltip": ""
+});

--- a/src/plugins/extra/videoblock/nls/de/i18n.js
+++ b/src/plugins/extra/videoblock/nls/de/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "Video",
+	"button.removevideo.tooltip": "Video entfernen"
+});

--- a/src/plugins/extra/videoblock/nls/i18n.js
+++ b/src/plugins/extra/videoblock/nls/i18n.js
@@ -1,0 +1,13 @@
+define({
+	"root":  {
+		"tab.video.label": "Video: ",
+		"button.removevideo.tooltip": "Remove video"
+	},
+		"ca": true,
+		"de": true,
+		"mk": true,
+		"pt-br": true,
+		"ru": true,
+		"uk": true,
+		"zh-hans": true
+});

--- a/src/plugins/extra/videoblock/nls/mk/i18n.js
+++ b/src/plugins/extra/videoblock/nls/mk/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "",
+	"button.removevideo.tooltip": ""
+});

--- a/src/plugins/extra/videoblock/nls/pt-br/i18n.js
+++ b/src/plugins/extra/videoblock/nls/pt-br/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "",
+	"button.removevideo.tooltip": ""
+});

--- a/src/plugins/extra/videoblock/nls/ru/i18n.js
+++ b/src/plugins/extra/videoblock/nls/ru/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "",
+	"button.removevideo.tooltip": ""
+});

--- a/src/plugins/extra/videoblock/nls/uk/i18n.js
+++ b/src/plugins/extra/videoblock/nls/uk/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "",
+	"button.removevideo.tooltip": ""
+});

--- a/src/plugins/extra/videoblock/nls/zh-hans/i18n.js
+++ b/src/plugins/extra/videoblock/nls/zh-hans/i18n.js
@@ -1,0 +1,4 @@
+define({
+	"tab.video.label": "",
+	"button.removevideo.tooltip": ""
+});


### PR DESCRIPTION
The VideoBlock Plugin allows you to paste a YouTube URL into the active editable and it will be replaced by the appropriate iframe embed code. (Changelog is currently missing, will be added by Clemens!)
