### PR TITLE
New check for block-level-elements

### DIFF
--- a/build/changelog/entries/2014/04/10063.RT57987.bugfix
+++ b/build/changelog/entries/2014/04/10063.RT57987.bugfix
@@ -1,0 +1,2 @@
+Performing unformatting on a selection adjacent to a terminal whitespace sometimes caused a <br> to be erroneously inserted.
+This behaviour has been fixed.

--- a/src/lib/util/dom.js
+++ b/src/lib/util/dom.js
@@ -506,7 +506,8 @@ define(['jquery', 'util/class', 'aloha/ecma5shims'], function (jQuery, Class, $_
 						// text node
 						secondPart = document.createTextNode(element.data.substring(splitPosition, element.data.length));
 						element.data = element.data.substring(0, splitPosition);
-						if (this.isEmpty(secondPart) && jQuery('br', newDom).length === 0) {
+						// this is done to make sure that empty block elements are visible.
+						if (this.isBlockLevelElement(element.parentElement) && this.isEmpty(secondPart) && jQuery('br', newDom).length === 0) {
 							secondPart = jQuery('<br/>').addClass('aloha-end-br');
 						}
 					} else {


### PR DESCRIPTION
Performing unformatting on a selection adjacent to a terminal whitespace sometimes caused a <br> to be erroneously inserted.
