### PR TITLE
Image-Plugin: hide when plugin is deactivated for editable

### DIFF
--- a/build/changelog/entries/2014/04/10067.bugfix
+++ b/build/changelog/entries/2014/04/10067.bugfix
@@ -1,0 +1,4 @@
+Image-plugin: hide the button in the UI when plugin is deactivated for an editable
+
+The problem was that an empty config for an editable did not deactivate the image-plugin as described in the guides.
+

--- a/src/demo/boilerplate/js/aloha-config.js
+++ b/src/demo/boilerplate/js/aloha-config.js
@@ -135,16 +135,9 @@
 						'oneTab': true
 					}
 				},
-				'fixedAspectRatio' : false,
-				'maxWidth'         : 600,
-				'minWidth'         : 20,
-				'maxHeight'        : 600,
-				'minHeight'        : 20,
-				'globalselector'   : '.global',
-				'ui': {
-					'oneTab' : true,
-					'align'  : false,
-					'margin' : false
+				editables: {
+					// deactivae image plugin for editable with id #top-text
+					'#top-text' : []
 				}
 			},
 			cite: {

--- a/src/plugins/common/image/lib/image-plugin.js
+++ b/src/plugins/common/image/lib/image-plugin.js
@@ -404,11 +404,12 @@ define([
 					foundMarkup = plugin.findImgMarkup(rangeObject);
 					config = plugin.getEditableConfig(Aloha.activeEditable.obj);
 
-					if (typeof config !== 'undefined') {
-						plugin.ui._insertImageButton.show();
-					} else {
+					// check for empty config and hide button in ui
+					if (!config || (jQuery.isArray(config) && config.length < 1)) {
 						plugin.ui._insertImageButton.hide();
 						return;
+					} else {
+						plugin.ui._insertImageButton.show();
 					}
 
 					// Enable image specific ui components if the element is an image


### PR DESCRIPTION
Image-plugin: hide the button in the UI when plugin is deactivated for an editable

The problem was that an empty config for an editable did not deactivate the image-plugin as described in the guides.
