### PR TITLE
Adds a getter to the Aloha object to get its plugin manager.

### DIFF
--- a/src/lib/aloha/core.js
+++ b/src/lib/aloha/core.js
@@ -593,7 +593,7 @@ define([
 		 */
 		getPluginManager: function () {
 			return PluginManager;
-		}
+		},
 
 		/**
 		 * Disable object resizing by executing command 'enableObjectResizing',


### PR DESCRIPTION
I couldn't find a way to get to the PluginManager object used by Aloha (need to reach to the loaded plugins by the plugin manager), and I couldn't find a way to do that without adding this getter.
