### PR TITLE
Firefox: Correct range when selecting text with key command 'shift+keydo...

### DIFF
--- a/build/changelog/entries/2014/06/10090.RT50706.bugfix
+++ b/build/changelog/entries/2014/06/10090.RT50706.bugfix
@@ -1,0 +1,4 @@
+(Only for Firefox browsers) When selecting a paragraph with the command 'shift+keydown', the selection
+ends in the start of the next paragraph  instead of at the end of the selected paragraph. This produces
+an unexpected behaviour when formatting the selected text to a heading or a list, because the  result
+included one extra paragraph. This issue has bee fixed.

--- a/src/plugins/common/list/lib/list-plugin.js
+++ b/src/plugins/common/list/lib/list-plugin.js
@@ -240,6 +240,7 @@ define([
 		 * @return dom object or false
 		 */
 		getStartingDomObjectToTransform: function () {
+			Aloha.Selection.checkForFirefoxIncorrectRange();
 			var rangeObject = Aloha.Selection.rangeObject,
 				i, effectiveMarkup;
 


### PR DESCRIPTION
...wn'
