### PR TITLE
Fix multi-line elements #1138

### DIFF
--- a/src/ranges.js
+++ b/src/ranges.js
@@ -657,7 +657,7 @@ define([
 	 * @return {?Object.<string, number>}
 	 */
 	function boundingRect(reference) {
-		var rect = reference.getBoundingClientRect();
+		var rect = reference.getClientRects()[0] || reference.getBoundingClientRect();
 		return {
 			top    : rect.top,
 			left   : rect.left,


### PR DESCRIPTION
`<div class="aloha-editable">on{}<b>e<br>t</b>wo<br></div>`
https://github.com/alohaeditor/Aloha-Editor/issues/1138#issuecomment-50032420
