### PR TITLE
Selecting and typing text.

### DIFF
--- a/src/typing.js
+++ b/src/typing.js
@@ -398,7 +398,7 @@ define([
 			if (handling.undo) {
 				undoable(handling.undo, event, function () {
 					if (handling.deleteRange && !range.collapsed) {
-						remove(false, event);
+						event.range = remove(false, event);
 					}
 					event.range = handling.mutate(event);
 					Html.prop(range.commonAncestorContainer);


### PR DESCRIPTION
When selecting and typing text, the range was wrong, so the text was inserted in the wrong position.
