### PR TITLE
Fix incorrect configuration check in handler for

### DIFF
--- a/build/changelog/entries/2014/09/10109.RT58482.bugfix
+++ b/build/changelog/entries/2014/09/10109.RT58482.bugfix
@@ -1,0 +1,2 @@
+autoparagraph-plugin: The autoparagraph plugin did not work as expected. Paragraphs were only created for new editables (upon "aloha.editable.created") but not when the content in an editable changed ("aloha-smart-content-changed").
+This has been fixed now. The paragraphs will now also be created (if necessary) when content changes.

--- a/src/plugins/common/autoparagraph/lib/autoparagraph-plugin.js
+++ b/src/plugins/common/autoparagraph/lib/autoparagraph-plugin.js
@@ -168,7 +168,7 @@ define([
 
 			// autogenerate paragraphs upon smart content change
 			Aloha.bind('aloha-smart-content-changed', function (event, data) {
-				if (configurations[data.editable.obj]) {
+				if (configurations[data.editable.getId()]) {
 					autogenerateParagraphs(data.editable);
 				}
 			});


### PR DESCRIPTION
aloha-smart-content-changed, which prevented any generation of paragraphs
on content change. Fixes RT#58482
