### PR TITLE
Add workaround function to properly read the offsetHeight of a DOM

### DIFF
--- a/build/changelog/entries/2014/10/10117.RT58526.bugfix
+++ b/build/changelog/entries/2014/10/10117.RT58526.bugfix
@@ -1,0 +1,4 @@
+In Internet Explorer 7 (or newer versions of Internet Explorer in IE7 mode), sometimes reading the offsetHeight of a DOM element
+would return 0 for the first access. Only when reading the offsetHeight again, the correct value would be returned.
+This bugfix adds a workaround method to get the offsetHeight of a DOM element, which reads twice if the first returned value happens to be 0.
+This fixes various problems connected with reading the offsetHeight.

--- a/src/lib/util/dom.js
+++ b/src/lib/util/dom.js
@@ -1827,7 +1827,7 @@ define(['jquery', 'util/class', 'aloha/ecma5shims'], function (jQuery, Class, $_
 			}
 
 			// check whether the node itself is visible
-			if ((node.nodeType == $_.Node.TEXT_NODE && this.isEmpty(node)) || (node.nodeType == $_.Node.ELEMENT_NODE && node.offsetHeight == 0 && jQuery.inArray(node.nodeName.toLowerCase(), this.nonEmptyTags) === -1)) {
+			if ((node.nodeType == $_.Node.TEXT_NODE && this.isEmpty(node)) || (node.nodeType == $_.Node.ELEMENT_NODE && this.getOffsetHeight(node) === 0 && jQuery.inArray(node.nodeName.toLowerCase(), this.nonEmptyTags) === -1)) {
 				return null;
 			}
 
@@ -1861,7 +1861,7 @@ define(['jquery', 'util/class', 'aloha/ecma5shims'], function (jQuery, Class, $_
 			}
 
 			// check whether the node itself is visible
-			if ((node.nodeType == $_.Node.TEXT_NODE && this.isEmpty(node)) || (node.nodeType == $_.Node.ELEMENT_NODE && node.offsetHeight == 0 && jQuery.inArray(node.nodeName.toLowerCase(), this.nonEmptyTags) === -1)) {
+			if ((node.nodeType == $_.Node.TEXT_NODE && this.isEmpty(node)) || (node.nodeType == $_.Node.ELEMENT_NODE && this.getOffsetHeight(node) === 0 && jQuery.inArray(node.nodeName.toLowerCase(), this.nonEmptyTags) === -1)) {
 				return null;
 			}
 
@@ -1880,6 +1880,25 @@ define(['jquery', 'util/class', 'aloha/ecma5shims'], function (jQuery, Class, $_
 			}
 
 			return null;
+		},
+
+		/**
+		 * Workaround to get the offsetHeight from a DOM node. IE7 (and all IEs in IE7 mode) have a very weird bug that
+		 * returns 0 when reading the offsetHeight from a DOM node for the first time. When reading again (without any
+		 * modification in between), the correct value would be returned.
+		 * Therefore, this method will get the offsetHeight and if it is 0, read it again.
+		 * @param {DOMObject} node
+		 * @return {number} offsetHeight
+		 */
+		getOffsetHeight: function (node) {
+			if (!node) {
+				return 0;
+			}
+			var offsetHeight = node.offsetHeight;
+			if (offsetHeight === 0) {
+				offsetHeight = node.offsetHeight;
+			}
+			return offsetHeight;
 		}
 	});
 


### PR DESCRIPTION
element. IE7 (and newer versions of IE in IE7 mode) sometimes would return
0 for the offsetHeight and only upon reading the value again would reveal
the correct value.
