### PR TITLE
Fix deleting of br, hr or img tags at the end of an inline editable tag

### DIFF
--- a/build/changelog/entries/2014/10/10124.RT58605.bugfix
+++ b/build/changelog/entries/2014/10/10124.RT58605.bugfix
@@ -1,0 +1,1 @@
+It was not possible to delete a br, hr or img tag at the end of an inline element (like an a) by pressing the "delete" button. This has been fixed now.

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -7309,11 +7309,6 @@ define([
 				return;
 			}
 
-			// "If node is an inline node, abort these steps."
-			if (isInlineNode(node)) {
-				return;
-			}
-
 			// "If node has a child with index offset and that child is a br or hr
 			// or img, call collapse(node, offset) on the Selection. Then delete
 			// the contents of the range with start (node, offset) and end (node,
@@ -7322,6 +7317,11 @@ define([
 				range.setStart(node, offset);
 				range.setEnd(node, offset);
 				deleteContents(node, offset, node, offset + 1);
+				return;
+			}
+
+			// "If node is an inline node, abort these steps."
+			if (isInlineNode(node)) {
 				return;
 			}
 


### PR DESCRIPTION
(like a).
