### PR TITLE
Add missing link in doc to texcolor plugin page

### DIFF
--- a/doc/guides/source/plugins.textile
+++ b/doc/guides/source/plugins.textile
@@ -100,6 +100,7 @@ Plugins in the @extra@ directory:
 * "extra/ribbon":plugin_ribbon.html - this plugin is intended to provide a Ribbon which is displayed on top of the page and some controls can be added to it dynamically
 * "extra/sourceview":plugin_sourceview.html - view the source of an editable including selection marks in the sidebar
 * "extra/speak°":plugin_speak.html - integrates speak.js into Aloha Editor
+* "extra/texcolor":plugin_textcolor.html - apply colors to your text
 * "extra/toc":plugin_toc.html - add a table of contents into your editable
 * "extra/vie":plugin_vie.html - integrates VIE.js into Aloha Editor
 * "extra/wai-lang":plugin_wai-lang.html - annotate parts of the content with @lang@ attributes


### PR DESCRIPTION
Add missing link to the textcolor plugin page on the plugins overview in the docs
