### PR TITLE
Fix saving language annotations in IE9

### DIFF
--- a/build/changelog/entries/2015/01/10164.RT58603.bugfix
+++ b/build/changelog/entries/2015/01/10164.RT58603.bugfix
@@ -1,0 +1,1 @@
+Wai-lang plugin: when adding a language annotation, the change is not saved correctly in IE9. This has been fixed.

--- a/src/lib/util/dom2.js
+++ b/src/lib/util/dom2.js
@@ -141,18 +141,29 @@ define([
 	 */
 	function attrs(elem) {
 		var as = [];
+		var visited = {};
 		var names = attrNames(elem);
 		var i;
 		var len;
 		for (i = 0, len = names.length; i < len; i++) {
 			var name = names[i];
 			var value = $.attr(elem, name);
+			//IE9 Fix, "lang" value not in attributes
+			if (name === "lang"){
+				if (elem.lang) {
+					value = elem.lang;
+				}
+			}
 			if (null == value) {
 				value = "";
 			} else {
 				value = value.toString();
 			}
-			as.push([name, value]);
+			//filter duplicates. IE 10 doesn't take care of duplicates
+			if (!(name in visited)) {
+				as.push([name, value]);
+				visited[name] = true;
+			}
 		}
 		return as;
 	}

--- a/src/plugins/extra/wai-lang/lib/wai-lang-plugin.js
+++ b/src/plugins/extra/wai-lang/lib/wai-lang-plugin.js
@@ -54,6 +54,11 @@ define([
 	var removeButton = null;
 
 	/**
+	 * True if IE9
+	 */
+	var isIE9 = Aloha.browser.msie && parseInt(Aloha.browser.version, 10) === 9;
+
+	/**
 	 * Sets focus on the given field.
 	 *
 	 * @param {AttributeField} field
@@ -93,7 +98,8 @@ define([
 	 */
 	function filterForWaiLangMarkup() {
 		var $elem = $(this);
-		return $elem.hasClass(WAI_LANG_CLASS) || $elem.is('[lang]');
+		//IE9 Fix, "lang" value not in dom attributes, use "xml:lang" instead
+		return $elem.hasClass(WAI_LANG_CLASS) || $elem.is('[lang]' || $elem.is('[xml\\:lang'));
 	}
 
 	/**
@@ -181,7 +187,7 @@ define([
 		var $element = $(element);
 		$element.addClass(WAI_LANG_CLASS)
 		        .attr('data-gentics-aloha-repository', 'wai-languages')
-		        .attr('data-gentics-aloha-object-id', $element.attr('lang'));
+		        .attr('data-gentics-aloha-object-id', $element.attr(isIE9 ? 'xml:lang' : 'lang'));
 	}
 
 	/**
@@ -304,7 +310,9 @@ define([
 				var markup = findWaiLangMarkup(range);
 				if (markup) {
 					plugin._wailangButton.setState(true);
-					FIELD.setTargetObject(markup, 'lang');
+					//IE9 Fix, "lang" value not in dom attributes,
+					//use "xml:lang" instead
+					FIELD.setTargetObject(markup, isIE9 ? 'xml:lang' : 'lang');
 
 					// show the field and remove button
 					FIELD.show();
@@ -343,8 +351,9 @@ define([
 						// then META+I to manually do that.
 						return false;
 					});
-
-				editable.obj.find('span[lang]').each(function () {
+				//IE9 Fix, "lang" value not in dom attributes,
+				//use "xml:lang" instead
+				editable.obj.find(isIE9 ? 'span[xml\\:lang]' : 'span[lang]').each(function () {
 					annotate(this);
 				});
 			});
@@ -432,13 +441,21 @@ define([
 		 *                                       element to clean up.
 		 */
 		makeClean: function makeClean($element) {
-			$element.find('span[lang]').each(function onEachLangSpan() {
-				var $span = $(this);
-				$span.removeClass(WAI_LANG_CLASS)
-				     .removeAttr('data-gentics-aloha-repository')
-				     .removeAttr('data-gentics-aloha-object-id')
-				     .attr('xml:lang', $span.attr('lang'));
-			});
+			//IE9 Fix, "lang" value not in dom attributes,
+			//use "xml:lang" instead
+			$element.find(isIE9 ? 'span[xml\\:lang]' : 'span[lang]')
+				.each(function onEachLangSpan() {
+					var $span = $(this);
+					$span.removeClass(WAI_LANG_CLASS)
+					     .removeAttr('data-gentics-aloha-repository')
+					     .removeAttr('data-gentics-aloha-object-id');
+					if (isIE9) {
+						$span.attr('lang', $span.attr('xml:lang'));
+						$span.lang = $span.attr('xml:lang');
+					} else {
+						$span.attr('xml:lang', $span.attr('lang'));
+					}
+				});
 		}
 
 	});


### PR DESCRIPTION
Wai-lang plugin: when adding a language annotation, the change is not saved correctly in IE9. This has been fixed.