### PR TITLE
Safely remove placeholder div

### DIFF
--- a/build/changelog/entries/2015/01/10173.SUP-197.bugfix
+++ b/build/changelog/entries/2015/01/10173.SUP-197.bugfix
@@ -1,0 +1,1 @@
+When moving the curser between two blocks a <div> was inserted to make the space visible for editing. This <div> was not cleaned up after editing. Now the <div> will be safely removed, keeping its content.

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -226,6 +226,50 @@ define([
 		});
 	}
 
+	/**
+	 * This function is used for safely removing a placeholder without losing
+	 * valuable information.
+	 * @param {Editable} obj the editable in which to remove the placeholder
+	 * @param {string} placeholderClass the name of the placeholder class
+	 */
+	function safelyRemovePlaceholder(obj, placeholderClass) {
+		jQuery('.' + placeholderClass, obj).each(function(index, value) {
+				var $value = $(value);
+				//preserve content if the placeholder is an aloha-editable-div
+				if ($value.hasClass("aloha-editable-div")) {
+					var child = $value[0].firstChild;
+
+					//delete the none-breaking space that has been inserted to
+					//make the div visible for editing
+					if (child) {
+						if (child.nodeType !== 3 || child.data.indexOf('\u00A0') === -1){
+								child = $value[0].lastChild;
+						}
+						if (child.nodeType === 3) {
+							var innerText = child.data;
+							//the none-breaking space could be the first or the
+							//last character
+							if (innerText.indexOf('\u00A0') > -1) {
+								innerText = innerText.replace(/^(\u00A0)*/, '');
+								if (innerText.indexOf('\u00A0') > -1) {
+									innerText = innerText.replace(/(\u00A0)*$/, '');
+								}
+								child.data = innerText;
+							}
+						}
+					}
+
+					if(!$value.is(':empty')){
+						Dom.removeShallow(value);
+					}else{
+						value.remove();
+					}
+				} else {
+					value.remove();
+				}
+			});
+	}
+
 	$(document).keydown(onKeydown);
 
 	/**
@@ -568,12 +612,12 @@ define([
 					range = new Selection.SelectionRange();
 					range.startContainer = range.endContainer = obj.get(0);
 					range.startOffset = range.endOffset = 0;
-					jQuery('.' + placeholderClass, obj).remove();
+					safelyRemovePlaceholder(obj, placeholderClass);
 					range.select();
 
 				}, 100);
 			} else {
-				jQuery('.' + placeholderClass, obj).remove();
+				safelyRemovePlaceholder(obj, placeholderClass);
 			}
 		},
 

--- a/src/lib/aloha/markup.js
+++ b/src/lib/aloha/markup.js
@@ -200,11 +200,11 @@ define([
 
 	function cleanupPlaceholders(range) {
 		if (window.$_alohaPlaceholder && !isInsidePlaceholder(range)) {
-			if (0 === window.$_alohaPlaceholder.html().replace(/^(&nbsp;)*$/, '').length) {
+			var placeholder = window.$_alohaPlaceholder.html().replace(/^(&nbsp;)*$/, '');
+			if (0 === placeholder.length) {
 				window.$_alohaPlaceholder.remove();
+				window.$_alohaPlaceholder = null;
 			}
-
-			window.$_alohaPlaceholder = null;
 		}
 	}
 
@@ -219,7 +219,7 @@ define([
 		var sibling = isGoingLeft ? prevVisibleNode(block) : nextVisibleNode(block);
 
 		if (!sibling || isBlock(sibling)) {
-			var $landing = jQuery('<div>&nbsp;</div>');
+			var $landing = jQuery('<div class="aloha-placeholder aloha-editable-div">&nbsp;</div>');
 
 			if (isGoingLeft) {
 				jQuery(block).before($landing);


### PR DESCRIPTION
When moving the curser between two blocks a <div> was inserted to make the space visible for editing. This <div> was not cleaned up after editing. Now the <div> will be safely removed, keeping its content.