### PR TITLE
Removed the focus() on the editable before pasting as it caused a scroll...

### DIFF
--- a/src/plugins/common/paste/lib/paste-plugin.js
+++ b/src/plugins/common/paste/lib/paste-plugin.js
@@ -124,10 +124,6 @@ define([
 	 * @param {WrappedRange} range The range to restore.
 	 */
 	function restoreSelection(range) {
-		var editable = CopyPaste.getEditableAt(range);
-		if (editable) {
-			editable.obj.focus();
-		}
 		CopyPaste.setSelectionAt(range);
 		window.scrollTo(
 			scrollPositionBeforePaste.x,


### PR DESCRIPTION
... to the top of the editable. I am not sure why it was put there in the first place. I had a look at the log and suspect that it was an act of desperation or put there as overkill.