### PR TITLE
build.sh: specify bash with hashbang

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function help {
 	echo -e "
 Aloha Editor build script


### PR DESCRIPTION
This way users of other shells like `zsh` can just execute the script normally.