### PR TITLE
Fix broken layout of aloha editor controls when page has

### DIFF
--- a/build/changelog/entries/2015/02/10181.SUP-66.bugfix
+++ b/build/changelog/entries/2015/02/10181.SUP-66.bugfix
@@ -1,0 +1,4 @@
+When editing pages having the style "direction" set to "rtl", the aloha editor controls like
+the toolbar, sidebar and repository browser where also affected which broke the layout and the functionality.
+This has been changed, so that all aloha editor controls will have "direction" set to "ltr" regardless of the
+page setting.

--- a/src/lib/vendor/repository-browser/css/repository-browser.css
+++ b/src/lib/vendor/repository-browser/css/repository-browser.css
@@ -437,6 +437,7 @@ div.repository-browser-modal-window {
 	left: 0;
 	z-index: 9999;
 	font-family: Arial, sans-serif;
+	direction: ltr;
 }
 
 .repository-browser-modal-window .ui-widget {

--- a/src/plugins/common/ui/css/ui.css
+++ b/src/plugins/common/ui/css/ui.css
@@ -14,6 +14,8 @@
  * http://docs.jquery.com/UI/Dialog#theming
  */
 
+.aloha-ui { direction: ltr; }
+
 .aloha.ui-dialog { position: absolute; padding: .2em; width: 300px; overflow: hidden; }
 .aloha.ui-dialog .ui-dialog-titlebar { padding: .4em 1em; position: relative;  }
 .aloha.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; } 


### PR DESCRIPTION
"direction" set to "rtl".