### PR TITLE
Add workaround for delete behaviour in blockmanager,

### DIFF
--- a/build/changelog/entries/2015/03/10190.SUP-501.bugfix
+++ b/build/changelog/entries/2015/03/10190.SUP-501.bugfix
@@ -1,0 +1,3 @@
+When using the block plugin and the table plugin, sometimes when selecting something
+in a table cell and pressing either "delete" or "backspace", the whole table was deleted.
+This has been fixed now.

--- a/src/plugins/common/block/lib/blockmanager.js
+++ b/src/plugins/common/block/lib/blockmanager.js
@@ -224,6 +224,11 @@ define([
 			Aloha.bind('aloha-command-will-execute', function (e, data) {
 				var commandId = data.commandId;
 
+				// workaround for selection problem in tables: we never delete table blocks this way
+				if (that._activeBlock && that._activeBlock.$element.hasClass('aloha-table-wrapper')) {
+					return true;
+				}
+
 				// Internet Explorer *magically* sets the range to the "Body" object after deselecting everything. yeah :-D
 				var selection = Aloha.getSelection(),
 				    rangeCount = selection.getRangeCount(),


### PR DESCRIPTION
when selection is in a table.