### PR TITLE
Table plugin: errors with forwarddelete

### DIFF
--- a/build/changelog/entries/2015/03/10204.SUP-622.bugfix
+++ b/build/changelog/entries/2015/03/10204.SUP-622.bugfix
@@ -1,0 +1,4 @@
+Errors in table-plugin:
+* When pressing delete in a paragraph right before a link with a table after the paragraph, the cursor will jump into the first table cell.
+* When pressing delete in a link in the last position before a table, the cursor will not jump into the first table cell but the table gets deleted.
+Both errors have been fixed.

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -474,20 +474,38 @@ define([
 			return false;
 		}
 
+		/**
+		 * Get the next sibling of the parent that is not null.
+		 * If the parent has no sibling, get the next sibling of it's parent.
+		 * Repeat until a sibling is found or the parent is null
+		 * @param  {Node} node
+		 * @return {Node}
+		 */
+		function getNextParentSiblingRecur(node) {
+			if (node.parentNode) {
+				return node.parentNode.nextSibling || getNextParentSiblingRecur(node.parentNode);
+			} else {
+				return null;
+			}
+		}
+
 		Aloha.bind('aloha-command-will-execute', function (_, event){
 			var range = Aloha.getSelection().getRangeAt(0);
-			var adjacent;
+			var adjacent = null;
+			//if forwarddelete is invoked before the table, jump into first table cell instead of deleting the table
 			if ('forwarddelete' === event.commandId) {
 				if (!range.collapsed || !isRangeVisiblyAtRightBoundary(range)) {
 					return;
 				}
 				var node = range.commonAncestorContainer;
 				if (3 === node.nodeType) {
-					adjacent = node.parentNode
-					        && Html.findNodeLeft(
-								node.parentNode.nextSibling,
-								isNotUnrenderedNode
-							);
+					if(node.nextSibling === null) {
+						adjacent = node.parentNode
+						        && Html.findNodeLeft(
+						           getNextParentSiblingRecur(node),
+									isNotUnrenderedNode
+								);
+					}
 				} else if (1 === node.nodeType) {
 					adjacent = Html.findNodeLeft(
 						node.nextSibling,
@@ -747,7 +765,6 @@ define([
 		thisWai.removeClass(waiGreen + ' ' + waiRed);
 
 		// Y U NO explain why we must check that summary is longer than 5 characters?
-		// http://cdn3.knowyourmeme.com/i/000/089/665/original/tumblr_l96b01l36p1qdhmifo1_500.jpg
 
 		if (jQuery.trim(this.obj[0].summary) !== '') {
 			thisWai.addClass(waiGreen);


### PR DESCRIPTION
Errors in table-plugin:
* When pressing delete in a paragraph right before a link with a table after the paragraph, the cursor will jump into the first table cell.
* When pressing delete in a link in the last position before a table, the cursor will not jump into the first table cell but the table gets deleted.

Fixed detecting, if the cursor should jump into the first cell of the next table on forwarddelete.
SUP-622