### PR TITLE
Improve text of tooltips for the buttons which increase/decrease indentation in lists. 

### DIFF
--- a/build/changelog/entries/2015/03/10205.SUP-675.bugfix
+++ b/build/changelog/entries/2015/03/10205.SUP-675.bugfix
@@ -1,0 +1,3 @@
+Improve text of tooltips for the buttons which increase/decrease indentation
+in lists. Escpecially the German tooltips where unclear in regard to the
+expected action of the buttons.

--- a/src/plugins/common/list/nls/de/i18n.js
+++ b/src/plugins/common/list/nls/de/i18n.js
@@ -1,7 +1,7 @@
 define({
 	"button.createulist.tooltip": "Unsortierte Liste einfügen",
 	"button.createolist.tooltip": "Sortierte Liste einfügen",
-	"button.indentlist.tooltip": "Liste einrücken",
-	"button.outdentlist.tooltip": "Liste ausrücken",
+	"button.indentlist.tooltip": "Einzug vergrößern",
+	"button.outdentlist.tooltip": "Einzug verkleinern",
 	"floatingmenu.tab.list": "Listen"
 });

--- a/src/plugins/common/list/nls/i18n.js
+++ b/src/plugins/common/list/nls/i18n.js
@@ -2,8 +2,8 @@ define({
 	"root":  {
 		"button.createulist.tooltip": "Insert Unordered List",
 		"button.createolist.tooltip": "Insert Ordered List",
-		"button.indentlist.tooltip": "Indent List",
-		"button.outdentlist.tooltip": "Outdent List",
+		"button.indentlist.tooltip": "Increase Indent",
+		"button.outdentlist.tooltip": "Decrease Indent",
 		"floatingmenu.tab.list": "Lists"
 	},
 		"ca": true,


### PR DESCRIPTION
Improve text of tooltips for the buttons which increase/decrease indentation in lists. 
Especially the German tooltips where unclear in regard to the expected action of the buttons.