### PR TITLE
Fixed disappearing cursor on forward-delete

### DIFF
--- a/build/changelog/entries/2015/03/10209.SUP-645.bugfix
+++ b/build/changelog/entries/2015/03/10209.SUP-645.bugfix
@@ -1,0 +1,2 @@
+After forward-deleting the last letter of a link, the cursor disappeared from the editable.
+This has been fixed.

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -7284,6 +7284,7 @@ define([
 	//@{
 	commands.forwarddelete = {
 		action: function (value, range) {
+			var deleteContentsRange;
 			// special behaviour for skipping zero-width whitespaces in IE7
 			if (Aloha.browser.msie && Aloha.browser.version <= 7) {
 				moveOverZWSP(range, true);
@@ -7402,8 +7403,14 @@ define([
 
 				// "Delete the contents of the range with start (node, offset) and
 				// end (node, end offset)."
-				deleteContents(node, offset, node, endOffset);
+				deleteContentsRange = deleteContents(node, offset, node, endOffset);
 
+				if (deleteContentsRange) {
+					// The new range position can only be determined inside deleteContents,
+					// that's why it's necessary to take over the range if one was returned.
+					range.setStart(deleteContentsRange.startContainer, deleteContentsRange.startOffset);
+					range.setEnd(deleteContentsRange.endContainer, deleteContentsRange.endOffset);
+				}
 				// "Abort these steps."
 				return;
 			}


### PR DESCRIPTION
After forward-deleting the last letter of a link, the cursor disappeared from the editable.
This has been fixed