### PR TITLE
Hide the insertLink button, when clicking into an editable

### DIFF
--- a/build/changelog/entries/2015/04/10212.SUP-740.bugfix
+++ b/build/changelog/entries/2015/04/10212.SUP-740.bugfix
@@ -1,0 +1,3 @@
+When having the cursor on a link (in an editable that allows links) and
+then clicking into an editable, that does not allow links, the "Insert Link"
+button was shown in the "Insert" tab of the toolbar. This has been fixed now.

--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -552,7 +552,19 @@ define([
 			}
 			this._isScopeActive = show;
 			this._isScopeActive_editableId = Aloha.activeEditable && Aloha.activeEditable.getId();
-			if ( show ) {
+			if (!configurations[this._isScopeActive_editableId]) {
+				this.hrefField.hide();
+				this._insertLinkButton.hide();
+				this._removeLinkButton.hide();
+				this._formatLinkButton.setState(false);
+				// The calls to enterScope and leaveScope by the link
+				// plugin are not balanced.
+				// When the selection is changed from one link to
+				// another, the link scope is incremented more than
+				// decremented, which necessitates the force=true
+				// argument to leaveScope.
+				Scopes.leaveScope(this.name, 'link', true);
+			} else if ( show ) {
 				this.hrefField.show();
 				this._insertLinkButton.hide();
 				// Never show the removeLinkButton when the link itself


### PR DESCRIPTION
that disallowes insertion of links.