### PR TITLE
Fix initialization of inline drag and drop behaviour,

### DIFF
--- a/build/changelog/entries/2015/04/10216.SUP-749.bugfix
+++ b/build/changelog/entries/2015/04/10216.SUP-749.bugfix
@@ -1,0 +1,4 @@
+It was not possible to drag and drop inline blocks (spans)
+between words of editables. Instead inline blocks could be dropped
+between block-level elements (like paragraphs).
+This has been fixed now.

--- a/src/plugins/common/block/lib/dragbehavior.js
+++ b/src/plugins/common/block/lib/dragbehavior.js
@@ -106,7 +106,11 @@ define([
 		this.blockObject = blockObject;
 		this.$element = blockObject.$element;
 		this.insertBeforeOrAfterMode = false;
-		this.setDraggable();
+		if (this.$element[0].nodeName === 'DIV') {
+			// this drag/drop behaviour is only suitable for DIV-blocks
+			// inline drag/drop is initialized somewhere else (block.js)
+			this.setDraggable();
+		}
 	}
 
 	PubSub.sub('aloha.block.initialized', function (data) {


### PR DESCRIPTION
which is done in block.js to not be overridden in dragbehavior.js