### PR TITLE
wordcontenthandler: Replace unnecessary new line characters (in text nodes) added by Word with space characters.

### DIFF
--- a/build/changelog/entries/2015/04/10220.SUP-845.bugfix
+++ b/build/changelog/entries/2015/04/10220.SUP-845.bugfix
@@ -1,0 +1,4 @@
+The Word content handler now replaces unnecessary new line characters 
+added by Word with spaces. This fixes bug SUP-845, in which spaces got 
+lost, because new line characters are automatically stripped when using
+the Text/HTML GCN tag part type.

--- a/src/plugins/common/contenthandler/lib/wordcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/wordcontenthandler.js
@@ -160,6 +160,29 @@ define([
 	}
 
 	/**
+	 * Replaces unnecessary new line characters within text nodes in Word HTML 
+	 * with a space.
+	 *
+	 * @param {jQuery.<HTMLElement>} $content
+	 */
+	function replaceWordNewLines($content) {
+		var i;
+		var $nodes = $content.contents();
+		var node;
+
+		for (i = 0; i < $nodes.length; i++) {
+			node = $nodes[i];
+
+			if (Node.TEXT_NODE === node.nodeType) {
+				var text = node.nodeValue;
+				node.nodeValue = text.replace(/[\r\n]+/gm, ' ');
+			} else {
+				replaceWordNewLines($nodes.eq(i));
+			}
+		}
+	}
+
+	/**
 	 * Cleanup MS Word HTML.
 	 *
 	 * @param {jQuery.<HTMLElement>} $content
@@ -198,6 +221,7 @@ define([
 		}
 
 		removeUnrenderedChildNodes($content);
+		replaceWordNewLines($content);
 	}
 
 	/**


### PR DESCRIPTION
This fixes issue SUP-845, where some spaces between words got lost in GCN when Word content was pasted to a tag, which used the Text/HTML part type (in this case all new lines are removed when saving the tag, which resulted in the lost spaces).

SUP-845