### PR TITLE
Fix multiple issues with placement of the caret before and after inline blocks

### DIFF
--- a/build/changelog/entries/2015/04/10222.SUP-841.bugfix
+++ b/build/changelog/entries/2015/04/10222.SUP-841.bugfix
@@ -1,0 +1,4 @@
+Fix multiple issues with placement of the caret before and after inline aloha-blocks. It was not possible to place the caret: 
+* next to an inline block (before or after) when the inline block was alone in a line (no paragraph)
+* after the block when it is the last element in a pragraph
+* between two inline aloha-blocks

--- a/src/demo/block/index.html
+++ b/src/demo/block/index.html
@@ -206,6 +206,18 @@
 				<p>Some other content here...</p>
 				<p><b>Stock Quote example:</b> When you hover over the name of the <span class="company" data-symbol="MSFT">Microsoft</span> company, the stock quotes are shown.</p>
 				<p>Some more content...</p>
+				<h3>Inline Element Caret Placement</h3>
+				<p>It should be possible to place the caret before and after Inline-Aloha-Blocks using mouse or keyboard</p>
+				<p>Some text before <span class="default-block">This are two inline blocks</span> <span class="default-block">next to each other</span>some text after.</p>
+				<p>Aloha Blocks like tables are not only possible on block-level but can also added in inline text:<br />
+					<span class="default-block">This is an Inline-Block standing alone in a line</span><br /><br />
+					<span class="default-block"><a href="#">This is an Inline-Block standing alone in a line - Content is wrapped in a html-element</a></span><br />
+				</p>
+				<p><span class="default-block">This is an Inline-Block standing alone in a paragraph</span></p>
+				<p><span class="default-block"><a href="#">This is an Inline-Block standing alone in a paragraph - Content is wrapped in a html-element</a></span></p>
+				<p><span class="default-block">This is an Inline-Block standing alone in a paragraph</span></p>
+				<p><span class="default-block"><a href="#">This is an Inline-Block alone in a paragraph - Content is wrapped in a html-element</a></span></p>
+				<p>Some text before <span class="default-block"><a href="#">This is an Inline-Block with sourrounding text - Content is wrapped in a html-element</a></span>Text after.</p>
 				<h3>Floating Element</h3>
 				<p><span class="imageBlock" data-position="right" style="float:right"><img src="blockdemo/img/stock-quote-aapl.gif" /></span>
 				Super Dodge Ball Advance,<span class="default-block">Some Text</span> released in Japan as Bakunetsu Dodgeball Fighters (爆熱ドッジボールファイターズ?, "Bakunetsu" meaning "Burning Heat"), dodge ball game based on the Super Dodge Ball. While based on the original Super Dodge Ball series, the game does not feature the Kunio-kun characters from the original game due to copyrights issues, as developer Million did not obtain the rights to the Kunio-kun characters until the following year.[citation needed] However, the game uses a remixed version of opening and ending songs from Technos Japan Corp's Super Dodge Ball games.
@@ -227,6 +239,18 @@
 				<p>Some other content here...</p>
 				<p><b>Stock Quote example:</b> When you hover over the name of the <span class="company" data-symbol="MSFT">Microsoft</span> company, the stock quotes are shown.</p>
 				<p>Some more content...</p>
+				<h3>Inline Element Caret Placement</h3>
+				<p>It should be possible to place the caret before and after Inline-Aloha-Blocks using mouse or keyboard</p>
+				<p>Some text before <span class="default-block">This are two inline blocks</span> <span class="default-block">next to each other</span>some text after.</p>
+				<p>Aloha Blocks like tables are not only possible on block-level but can also added in inline text:<br />
+					<span class="default-block">This is an Inline-Block standing alone in a line</span><br /><br />
+					<span class="default-block"><a href="#">This is an Inline-Block standing alone in a line - Content is wrapped in a html-element</a></span><br />
+				</p>
+				<p><span class="default-block">This is an Inline-Block standing alone in a paragraph</span></p>
+				<p><span class="default-block"><a href="#">This is an Inline-Block standing alone in a paragraph - Content is wrapped in a html-element</a></span></p>
+				<p><span class="default-block">This is an Inline-Block standing alone in a paragraph</span></p>
+				<p><span class="default-block"><a href="#">This is an Inline-Block alone in a paragraph - Content is wrapped in a html-element</a></span></p>
+				<p>Some text before <span class="default-block"><a href="#">This is an Inline-Block with sourrounding text - Content is wrapped in a html-element</a></span>Text after.</p>
 				<h3>Floating Element</h3>
 				<p><span class="imageBlock" data-position="right" style="float:right"><img src="blockdemo/img/stock-quote-aapl.gif" /></span>
 				Super Dodge Ball Advance,<span class="default-block">Some Text</span> released in Japan as Bakunetsu Dodgeball Fighters (爆熱ドッジボールファイターズ?, "Bakunetsu" meaning "Burning Heat"), dodge ball game based on the Super Dodge Ball. While based on the original Super Dodge Ball series, the game does not feature the Kunio-kun characters from the original game due to copyrights issues, as developer Million did not obtain the rights to the Kunio-kun characters until the following year.[citation needed] However, the game uses a remixed version of opening and ending songs from Technos Japan Corp's Super Dodge Ball games.

--- a/src/plugins/common/block/lib/block-utils.js
+++ b/src/plugins/common/block/lib/block-utils.js
@@ -50,6 +50,11 @@ define([
 		return node;
 	}
 
+	/**
+	 * Check if a node is an Aloha-Block
+	 * @param  {HTMLElement}  node the HTML-node to check
+	 * @return {boolean}      true if the node is a block
+	 */
 	function isAlohaBlock(node) {
 		return $(node).data('aloha-block-type') || false;
 	}
@@ -73,10 +78,24 @@ define([
 		}
 	}
 
+	/**
+	 * When creating the padding for inline blocks this function is used to determine how far to go
+	 * forward or backward in the dom structure.
+	 *
+	 * @param  {HTMLElement} node the HTML-node to check
+	 * @return {boolean}      true if the node is line-break ('br'), a block element or the editing host itself
+	 */
 	function untilNode(node) {
 		return node.nodeName.toLowerCase() === 'br' || Html.isBlock(node) || DomLegacy.isEditingHost(node);
 	}
 
+	/**
+	 * When creating the padding for inline blocks this function is used to determine how far to go
+	 * forward in the dom structure. This function calls untilNode() internally.
+	 *
+	 * @param  {HTMLElement} node the HTML-node to check
+	 * @return {boolean}      true if untilNode() returns true or the node is an Aloha-Block
+	 */
 	function untilNodeForward(node) {
 		return untilNode(node) || (node.previousSibling && DomLegacy.isEditingHost(node.previousSibling)) || isAlohaBlock(node);
 	}


### PR DESCRIPTION
Fix multiple issues with placement of the caret before and after inline aloha-blocks. It was not possible to place the caret: 
* next to an inline block (before or after) when the inline block was alone in a line (no paragraph)
* after the block when it is the last element in a pragraph
* between two inline aloha-blocks