### PR TITLE
Fix drag & drop behaviour of blocks:

### DIFF
--- a/build/changelog/entries/2015/04/10223.SUP-738.bugfix
+++ b/build/changelog/entries/2015/04/10223.SUP-738.bugfix
@@ -1,0 +1,4 @@
+Drag & Drop behaviour of blocks has been improved:
+* It is now possible to drop blocks into empty editables
+* When dragging and dropping a block into another editable, the editable will get activated
+* During dragging, the toolbar will be hidden


### PR DESCRIPTION
Enable dropping into empty editables
Hide toolbar while dragging
Activate editable the block has been dropped into