### PR TITLE
Update aloha-ui-links.js

### DIFF
--- a/demo/aloha-ui/js/aloha-ui-links.js
+++ b/demo/aloha-ui/js/aloha-ui-links.js
@@ -63,6 +63,14 @@
 		query('a.aloha-link-follow', doc, Dom.setAttr, 'href', href);
 		query('.aloha-action-target', doc, Dom.toggleClass, 'active', '_blank' === target);
 		Dom.addClass(anchor, 'aloha-active');
+		
+		// href property is editable in firefox if the link text is selected
+		var range = document.createRange();
+		range.selectNodeContents(anchor);
+		var sel = window.getSelection();
+		sel.removeAllRanges();
+		sel.addRange(range);
+		
 		Dom.addClass(toolbar, 'active');
 		positionToolbar(toolbar, anchor);
 		toolbar.querySelector('input').value = href;


### PR DESCRIPTION
the href property is editable in firefox if the link text is selected, however when a link is clicked using aloha-ui-links.js the text is not highlighted.
i modifed the open function in aloha.ui-links.js