### PR TITLE
Trigger smart-content-changed for new tables.

### DIFF
--- a/build/changelog/entries/2015/04/10225.SUP-869.bugfix
+++ b/build/changelog/entries/2015/04/10225.SUP-869.bugfix
@@ -1,0 +1,1 @@
+Table-plugin: Insertion of a new table will trigger a smart-content-changed event.

--- a/build/changelog/entries/2015/04/10226.SUP-869.bugfix
+++ b/build/changelog/entries/2015/04/10226.SUP-869.bugfix
@@ -1,0 +1,2 @@
+Block-plugin: When dropping an inline block into another editable,
+the target editable will be activated.

--- a/src/plugins/common/block/lib/block.js
+++ b/src/plugins/common/block/lib/block.js
@@ -845,6 +845,15 @@ define([
 					$currentDraggable = null;
 
 					editablesWhichNeedToBeCleaned = [];
+
+					// deactivate the current editable and activate the editable,
+					// the block has been dropped into. This will do necessary initializations that
+					// happen on activation of the editable
+					Aloha.deactivateEditable();
+					var editable = Aloha.getEditableHost(that.$element);
+					if (editable) {
+						editable.activate();
+					}
 				},
 				start: function () {
 					blockDroppedProperly = false;

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -1300,6 +1300,8 @@ define([
 				}
 			}
 
+			Aloha.activeEditable.smartContentChange({type: 'block-change'});
+
 			// The selection starts out in the first cell of the new
 			// table. The table tab/scope has to be activated
 			// accordingly.


### PR DESCRIPTION
Activate the target editable when dropping inline blocks