### PR TITLE
Table-Plugin: Fixed issues when the row or column tab was not shown in the menu

### DIFF
--- a/build/changelog/entries/2015/04/10228.SUP-834.bugfix
+++ b/build/changelog/entries/2015/04/10228.SUP-834.bugfix
@@ -1,0 +1,4 @@
+When multiple rows or columns where selected in a table, the "row" or "column" tab was not
+always shown in the floating menu. This has been fixed: the appropriate tabs are now
+always shown when a whole row or column is selected. Either through column or row selection
+or through selection of multiple cells.

--- a/src/demo/block/index.css
+++ b/src/demo/block/index.css
@@ -243,3 +243,12 @@ td.redwhite {
 .uneditableColumnBlock .clear {
 	clear:both;
 }
+
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+table td {
+	border: 1px solid;
+	padding: 3px;
+}

--- a/src/demo/block/index.html
+++ b/src/demo/block/index.html
@@ -288,10 +288,59 @@
 				<p>Williams, and other pilots who worked for British Airways claimed that their holiday pay was too low, because it only reflected his fixed salary, and not his bonuses. Williams' comprised a fixed annual salary, a "flying pay supplement" that went up the more he flew, and a "time away from base" which went up the more he was away from home. The flying and time away allowances were capped. Properly construed, his contract suggested that his holiday pay would be at the rate of only his fixed salary. Williams, however, contended that this was contrary to the Civil Aviation Working Time Directive,[1] as implemented by the Civil Aviation (Working Time) Regulations 2004,[2] (sector-specific implementations with the same objective as the Working Time Directive and the Working Time Regulations 1998 in this respect). In absence of particular provisions, the pay while on leave should be "normal remuneration". British Airways contended that because the Employment Rights Act 1996 sections 221 to 224 did not have provisions on how to determine a week's pay, the rate should be determined with reference to the contract.
 	The Employment Appeal Tribunal allowed Williams' claim, but this was reversed in the Court of Appeal.[3] The Supreme Court made a reference to the European Court of Justice.</p>
 			</div>
-
-
-
-			<hr /><hr /><hr />
+			<h2><a name="tables-blocks-inside"></a>Tables with blocks inside</h2>
+			<div class="textcontent">
+				<h3>Tables with Inline Blocks</h3>
+				<table summary="demo content for aloha tables">
+					<tbody>
+						<tr><td>A cell with <span class="default-block">a block at the end.</span></td><td>is</td><td>a</td><td>demo</td></tr>
+						<tr><td>table</td><td colspan=2 rowspan=2>with</td><td><span class="default-block">a single block in a cell</span></td></tr>
+						<tr><td>Some text <span class="default-block">with a block</span> in the middle</td><td>column</td></tr>
+						<tr><td>and</td><td><span class="default-block">a block at the beginning</span> of a cell</td><td>span</td><td><p>a cell with a paragraph and <span class="default-block">a block at the end.</span></p></td></tr>
+					</tbody>
+					<caption>describe the table</caption>
+				</table>
+				<p>Drag this inline aloha-block into the table: <span class="default-block">a block to drag</span></p>
+				<h3>Tables with Block-Level Blocks</h3>
+				<table summary="demo content for aloha tables">
+					<tbody>
+						<tr><td >This</td><td >is</td><td>a</td><td>demo</td></tr>
+						<tr>
+							<td>table</td>
+							<td colspan=2 rowspan=2>
+								<p><div class="default-block">
+									<p>This is a block level aloha block inside of a paragraph in a cell.</p>
+								</div></p>
+							</td>
+							<td>an</td></tr>
+						<tr>
+							<td>
+								<div class="editableImageBlock">
+									<img src="blockdemo/img/stock-quote-aapl.gif" />
+									<div class="aloha-editable">This Image Caption is editable through Aloha.</div>
+								</div>
+							</td>
+							<td>
+								awesome
+							</td>
+						</tr>
+						<tr>
+							<td>and</td><td>row</td><td>span</td>
+							<td>
+								<div class="default-block">
+									<p>This is a block level aloha block inside of a cell.</p>
+								</div>
+							</td>
+						</tr>
+					</tbody>
+					<caption>describe the table</caption>
+				</table>
+				<p>Drag this block-level aloha-block into the table</p>
+				<div class="editableImageBlock">
+					<img src="blockdemo/img/stock-quote-aapl.gif" />
+					<div class="aloha-editable">This Image Caption is editable through Aloha.</div>
+				</div>
+			</div>
 			<h2><a name="nested-blocks-editable"></a>Block which contains a variable number of editable columns</h2>
 			<h3>The following CMS systems use Aloha:</h3>
 			<div class="columnBlock" data-columns="3">

--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -133,6 +133,7 @@ define([
 				var grid = Utils.makeGrid($rows);
 
 				table.selection.selectedCells = [];
+				table.selection.currentRectangle = rect;
 				var selectClass = table.get('classCellSelected');
 				Utils.walkGrid(grid, function (cellInfo, j, i) {
 					if (Utils.containsDomCell(cellInfo)) {
@@ -218,6 +219,7 @@ define([
 
 				table.selection.selectedCells = [];
 				var selectClass = table.get('classCellSelected');
+				table.selection.currentRectangle = rect;
 				Utils.walkGrid(grid, function (cellInfo, j, i) {
 					if (Utils.containsDomCell(cellInfo)) {
 						if (i >= rect.top && i <= rect.bottom && j >= rect.left && j <= rect.right) {
@@ -421,7 +423,7 @@ define([
 			"left": left
 		};
 	};
-
+	
 	/**
 	 * Toggles selection of cell.
 	 * This works only when cell selection mode is active.
@@ -438,12 +440,14 @@ define([
 		var grid = Utils.makeGrid($rows);
 
 		table.selection.selectedCells = [];
+		table.selection.currentRectangle = rect;
 		var selectClass = table.get('classCellSelected');
 		Utils.walkGrid(grid, function (cellInfo, j, i) {
 			if (Utils.containsDomCell(cellInfo)) {
 				if (i >= rect.top && i <= rect.bottom && j >= rect.left && j <= rect.right) {
 					jQuery(cellInfo.cell).addClass(selectClass);
 					table.selection.selectedCells.push(cellInfo.cell);
+
 				} else {
 					jQuery(cellInfo.cell).removeClass(selectClass);
 				}

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -24,6 +24,7 @@ define([
 	'table/table-create-layer',
 	'table/table',
 	'table/table-plugin-utils',
+	'table/table-selection',
 	'util/dom',
 	'aloha/ephemera',
 	'aloha/console'
@@ -46,6 +47,7 @@ define([
 	CreateLayer,
 	Table,
 	Utils,
+	TableSelection,
 	Dom,
 	Ephemera,
 	Console
@@ -415,6 +417,7 @@ define([
 
 			// this case probably occurs when the selection is empty?
 			if (!range.startContainer || !editable) {
+				TablePlugin.leaveTableScopes();
 				return;
 			}
 
@@ -426,6 +429,7 @@ define([
 			}
 
 			if (!that.activeTable) {
+				TablePlugin.leaveTableScopes();
 				return;
 			}
 
@@ -437,6 +441,7 @@ define([
 				TablePlugin.updateFloatingMenuScope();
 				TablePlugin.setActiveCellStyle();
 			} else {
+				TablePlugin.leaveTableScopes();
 				that.activeTable.selection.cellSelectionMode = false;
 				that.activeTable.selection.baseCellPosition = null;
 				that.activeTable.selection.lastSelectionRange = null;
@@ -1461,9 +1466,56 @@ define([
 		return this.prefix;
 	};
 
+	/**
+	 * Leaves all possible TableScopes in the floating menu
+	 * expect those in the retainScopes array
+	 *
+	 * @param  {array} retainScopes the name of the scopes which should not be left
+	 */
+	TablePlugin.leaveTableScopes = function(retainScopes, force) {
+		var i = 0,
+			scopes = [];
+		retainScopes = $.isArray(retainScopes) ? retainScopes : [];
+
+		scopes = TableSelection.getPossibleSelectionTypes();
+		for (i = 0; i < scopes.length; i++) {
+			// leave all possible scopes expect those in the retainScopes array
+			if ($.inArray(scopes[i], retainScopes) === -1) {
+				// always force leaving the scope because otherwise we need to keep track of how
+				// often we entered the scope and leave it accordingly
+				Scopes.leaveScope(TablePlugin.name + '.' + scopes[i], undefined, true);
+			}
+		}
+	}
+	/**
+	 * Update the current floating menu scope according to the
+	 * selected cells
+	 */
 	TablePlugin.updateFloatingMenuScope = function() {
-		if ( null != TablePlugin.activeTable && null != TablePlugin.activeTable.selection.selectionType ) {
-			Scopes.setScope(TablePlugin.name + '.' + TablePlugin.activeTable.selection.selectionType);
+		var i = 0,
+			primaryScope,
+			scopes;
+		if (
+			null != TablePlugin.activeTable &&
+			null != TablePlugin.activeTable.selection.selectionType
+		) {
+			// save the primary scope
+			primaryScope = Scopes.getPrimaryScope(),
+			// get the new scopes
+			scopes = TablePlugin.activeTable.selection.getCurrentSelectionTypes();
+			// leave all scopes except the the current ones
+			TablePlugin.leaveTableScopes(scopes);
+			// Enter all needed table scopes
+			for (i = 0; i < scopes.length; i++) {
+				Scopes.enterScope(TablePlugin.name + '.' + scopes[i]);
+			}
+			// Check if the primaryScope changed and set the first scope as the currently active one
+			if (scopes[0] !== primaryScope) {
+				Scopes.setScope(TablePlugin.name + '.' + scopes[0]);
+			}
+		} else {
+			// leave all scopes
+			TablePlugin.leaveTableScopes();
 		}
 	};
 

--- a/src/plugins/common/table/lib/table-selection.js
+++ b/src/plugins/common/table/lib/table-selection.js
@@ -44,6 +44,12 @@ define([
 			));
 	}
 
+	var POSSIBLE_SELECTION_TYPES = [ 'cell', 'column', 'row' ];
+
+	TableSelection.getPossibleSelectionTypes = function () {
+		return POSSIBLE_SELECTION_TYPES;
+	};
+
 	/**
 	 * Gives the type of the cell-selection
 	 * possible values are "cell", "row", "column" or "all".
@@ -52,19 +58,24 @@ define([
 	TableSelection.prototype.selectionType = undefined;
 
 	/**
+	 * Stores the currently selected rectangle
+	 * @type {Object} the rectangle object
+	 */
+	TableSelection.prototype.currentRectangle = {};
+	/**
 	 * Holds all currently selected table cells as an array of DOM "td" representations
 	 */
-	TableSelection.prototype.selectedCells = new Array();
+	TableSelection.prototype.selectedCells = [];
 
 	/**
 	 * Holds all table columnIdx if selectiontype is column
 	 */
-	TableSelection.prototype.selectedColumnIdxs = new Array();
+	TableSelection.prototype.selectedColumnIdxs = [];
 
 	/**
 	 * Holds all table rowIds if selectiontype is column
 	 */
-	TableSelection.prototype.selectedRowIdxs = new Array();
+	TableSelection.prototype.selectedRowIdxs = [];
 
 	/**
 	 * Holds the active/disabled state of cell selection mode 
@@ -108,7 +119,7 @@ define([
 				}
 			}
 		}
-
+		this.currentRectangle.columns = this.selectedColumnIdxs;
 		this.selectionType = 'column';
 	};
 	
@@ -123,7 +134,6 @@ define([
 		var rows = this.table.getRows();
 		
  	    rowsToSelect.sort( function ( a, b ) { return a - b; } );
-
 		for (var i = 0; i < rowsToSelect.length; i++) {
 			if ( rows[ rowsToSelect[i] ] ) {
 				// check if this row is already selected.
@@ -141,6 +151,7 @@ define([
 			    }
 			}
 		}
+		this.currentRectangle.rows = this.selectedRowIdxs;
 
 	    this.selectionType = 'row';
 	};
@@ -223,9 +234,10 @@ define([
 				$(cells[i]).removeClass(classCellSelected);
 			}
 
-			this.selectedCells = new Array();
-			this.selectedColumnIdxs = new Array();
-			this.selectedRowIdxs = new Array();
+			this.selectedCells = [];
+			this.selectedColumnIdxs = [];
+			this.selectedRowIdxs = [];
+			this.currentRectangle = {};
 
 			//we keep 'cell' as the default selection type instead of
 			//unsetting the selectionType to avoid an edge-case where a
@@ -458,7 +470,7 @@ define([
 					splitable++;
 				}
 			});
-			
+
 			if ( splitable > 0 ) {
 				return true;
 			} else {
@@ -467,6 +479,51 @@ define([
 		} else {
 			return false;
 		}
+	};
+
+	/**
+	 * Gets the currenty active selection type from the selected
+	 * rectangle or the selected rows/columns.
+	 * The first element in the array is the selection type which is
+	 * most likely to be the most important one to the user.
+	 * (e.g. "table" if a whole table was selected or "row" when the whole row was selected)
+	 *
+	 * @return {array} an array of currently active selection types
+	 */
+	TableSelection.prototype.getCurrentSelectionTypes = function () {
+		var rect = this.currentRectangle;
+		var table = this.table;
+		var selectionTypes = [];
+
+		// check if a whole row was selected with row or cell selection
+		if (rect.rows || (rect.left === 1 && rect.right >= table.numCols)) {
+			selectionTypes.push('row');
+		}
+		// check if a whole column was selected with column or cell selection
+		if (rect.columns || (rect.top === 1 && rect.bottom >= table.numRows)) {
+			selectionTypes.push('column');
+		}
+		// if all rows and columns are selected using row, column or cell selection mark the whole table as selected
+		// put the "cell" selection type on the first position in the array to make sure it is selected
+		// as active tab in the toolbar
+		if (
+			// check if the whole table is selected with row selection
+			(rect.rows && rect.rows.length === table.numRows) ||
+			// check if the whole table is selected with column selection
+			(rect.columns && rect.columns.length === table.numCols) ||
+			// check if the whole table is selected with cell selection
+			($.inArray('row', selectionTypes) !== -1 && $.inArray('column', selectionTypes) !== -1)
+		) {
+			selectionTypes.unshift('cell');
+		// if row and column selection was not used, we know the cell selection was used and need to add this type in the array
+		} else if (!rect.rows && !rect.columns) {
+			selectionTypes.push('cell');
+		}
+		// as fallback use the selection type set with the old logic
+		if (selectionTypes.length === 0) {
+			selectionTypes.push(this.selectionType);
+		}
+		return selectionTypes;
 	};
 
 	return TableSelection;

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -1287,10 +1287,31 @@ define([
 
 		var grid = Utils.makeGrid(rows);
 		var selectColWidth = 1; //width of the select-row column
+		var selectedColumnIdxs = this.selection.selectedColumnIdxs;
+		// if at least on whole table column was selected using cell selection
+		// it should also be possible to delete the column
+		// therefore we need to determine which columns are selected using the 
+		// current rectangle 
+		if (
+			(!selectedColumnIdxs || selectedColumnIdxs.length === 0) &&
+			// check if the current rectangle is active
+			this.selection.currentRectangle &&
+			// check if a whole column is selected
+			this.selection.currentRectangle.top === 1 &&
+			this.selection.currentRectangle.bottom >= this.numRows &&
+			// check if there are really meaningful values in the rectangle
+			this.selection.currentRectangle.right > 0 &&
+			this.selection.currentRectangle.left > 0
+		) {
+			selectedColumnIdxs = [];
+			for (var l = this.selection.currentRectangle.left; l <= this.selection.currentRectangle.right; l++) {
+				selectedColumnIdxs.push(l);
+			}
+		}
 
 		// if all columns should be deleted, remove the WHOLE table
 		// delete the whole table
-		if ( this.selection.selectedColumnIdxs.length == grid[0].length - selectColWidth ) {
+		if ( selectedColumnIdxs.length == grid[0].length - selectColWidth ) {
 
 			Dialog.confirm({
 				title : i18n.t('Table'),
@@ -1309,7 +1330,8 @@ define([
 			//x-index is selected and deleted.
 
 			//sorted so we delete from right to left to minimize interfernce of deleted rows
-			var gridColumns = this.selection.selectedColumnIdxs.sort(function(a,b){ return b - a; });
+			
+			var gridColumns = selectedColumnIdxs.sort(function(a,b){ return b - a; });
 			for (var i = 0; i < gridColumns.length; i++) {
 				var gridColumn = gridColumns[i];
 				for (var j = 0; j < rows.length; j++) {
@@ -1723,8 +1745,6 @@ define([
 
 		this.selection.notifyCellsSelected();
 		this._removeCursorSelection();
-
-		Scopes.setScope(this.tablePlugin.name + '.column');
 	};
 
 	/**
@@ -1751,8 +1771,6 @@ define([
 
 		this.selection.notifyCellsSelected();
 		this._removeCursorSelection();
-
-		Scopes.setScope(this.tablePlugin.name + '.row');
 	};
 
 	/**


### PR DESCRIPTION
When multiple rows or columns where selected in a table, the "row" or "column" tab was not
always shown in the floating menu. This has been fixed: the appropriate tabs are now
always shown when a whole row or column is selected. Either through colum or row selection
or through selection of multiple cells.
