### PR TITLE
Fix adding end-br to transformed block-level elements.

### DIFF
--- a/build/changelog/entries/2015/05/10236.SUP-142.bugfix
+++ b/build/changelog/entries/2015/05/10236.SUP-142.bugfix
@@ -1,0 +1,6 @@
+When transforming empty block-level elements (e.g. change a paragraph to a pre-element),
+the block-level element did not always contain an ending break to make it visible.
+This has been fixed.
+Also the handling of placeholder paragraphs (landing zones before or after the first/last element
+in an editable) has been fixed. If placeholder paragraphs are filled, the classes marking them
+as placeholders are removed.

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -269,7 +269,8 @@ define([
 		if (isUnmodifiedAlohaEditingP(placeholder)) {
 			$placeholder.remove();
 		} else {
-			$placeholder.removeClass('aloha-editable-p');
+			$placeholder.removeClass('aloha-editing-p');
+			$placeholder.removeClass('aloha-placeholder');
 			if (Browser.ie) {
 				//remove trailing or leading word joiner
 				var child = $placeholder[0].firstChild;

--- a/src/lib/aloha/selection.js
+++ b/src/lib/aloha/selection.js
@@ -1332,6 +1332,7 @@ define([
 					if (Engine.isEditable(rangeObject.startContainer)) {
 						Engine.copyAttributes(rangeObject.startContainer, newMarkup[0]);
 						jQuery(rangeObject.startContainer).after(newMarkup[0]).remove();
+						Engine.ensureContainerEditable(newMarkup[0]);
 					} else if (Engine.isEditingHost(rangeObject.startContainer)) {
 						jQuery(rangeObject.startContainer).append(newMarkup[0]);
 						Engine.ensureContainerEditable(newMarkup[0]);


### PR DESCRIPTION
Correctly remove placeholder classes, if placeholder paragraph was filled.