### PR TITLE
Format-Plugin: Accept also string true for checkHeadingHierarchy option

### DIFF
--- a/build/changelog/entries/2015/05/10245.SUP-1028.bugfix
+++ b/build/changelog/entries/2015/05/10245.SUP-1028.bugfix
@@ -1,0 +1,3 @@
+Format-Plugin: The configuration of the checkHeadingHierarchy option would only be activated
+when a boolean "true" value was set in the settings. This has been fixed: the checkHeadingHierarchy
+option can now also be activated by using other truthy values (e.g.: string "true" or "1");

--- a/src/lib/util/strings.js
+++ b/src/lib/util/strings.js
@@ -112,11 +112,30 @@ define(['jquery'], function ($) {
 		return "" === str || null == str;
 	}
 
+	/**
+	 * Parse a boolean value from a string or any other type
+	 * this function returns true when the passed value is either
+	 * 'true', 'TRUE', '1', 1 (number) or true (boolean)
+	 *
+	 * @param  mixed value the value to parse
+	 * @return boolean     true if the value is considerd as "true"
+	 */
+	function parseBoolean(value) {
+		if (value === true || value === 1) {
+			return true;
+		} else if (typeof value === 'string' || value instanceof String) {
+			value = value.toLowerCase();
+			return value === 'true' || value === '1';
+		}
+		return false;
+	}
+
 	return {
 		words: words,
 		dashesToCamelCase: dashesToCamelCase,
 		camelCaseToDashes: camelCaseToDashes,
 		splitIncl: splitIncl,
-		empty: empty
+		empty: empty,
+		parseBoolean: parseBoolean
 	};
 });

--- a/src/plugins/common/format/lib/format-plugin.js
+++ b/src/plugins/common/format/lib/format-plugin.js
@@ -19,6 +19,7 @@ define('format/format-plugin', [
 	'util/dom',
 	'util/browser',
 	'util/maps',
+	'util/strings',
 	'ui/ui',
 	'ui/toggleButton',
 	'ui/port-helper-multi-split',
@@ -37,6 +38,7 @@ define('format/format-plugin', [
 	Dom,
 	Browser,
 	Maps,
+	Strings,
 	Ui,
 	ToggleButton,
 	MultiSplitButton,
@@ -647,7 +649,7 @@ define('format/format-plugin', [
 				me.initSidebar(Aloha.Sidebar.right);
 			});
 
-			var shouldCheckHeadingHierarchy = (true === this.settings.checkHeadingHierarchy);
+			var shouldCheckHeadingHierarchy = Strings.parseBoolean(this.settings.checkHeadingHierarchy);
 
 			var checkHeadings = function () {
 				checkHeadingHierarchy(me.formatOptions);


### PR DESCRIPTION
Format-Plugin: The configuration of the checkHeadingHierarchy option would only be activated when a boolean "true" value was set in the settings. This has been fixed: the checkHeadingHierarchy option can now also be activated by using other truthy values (e.g.: string "true" or "1");