### PR TITLE
Emptylinks-Plugin: fix faulty highlighting of empty links

### DIFF
--- a/build/changelog/entries/2015/05/10247.SUP-1045.bugfix
+++ b/build/changelog/entries/2015/05/10247.SUP-1045.bugfix
@@ -1,0 +1,2 @@
+Emptylink-Plugin: The emptylink-plugin would highlight all empty links on the whole page.
+This has been fixed now only empty links inside of editables will be hightlighted.

--- a/src/plugins/extra/emptylink/css/emptylink.css
+++ b/src/plugins/extra/emptylink/css/emptylink.css
@@ -1,3 +1,12 @@
-a[href='#'], a[href=''] {
+/* mark all anchor elements without name and href attribute */
+.aloha-editable a:not([name]):not([href]),
+/* mark all anchor elements with empty href attribute (including '#') and the name attribute not set */
+.aloha-editable a[href='#']:not([name]),
+.aloha-editable a[href='']:not([name]),
+/* mark all anchor elements with empty name attribute and the href attribute not set */
+.aloha-editable a[name='']:not([href]),
+/* mark all anchor elements with empty href (including '#') and empty name attribute */
+.aloha-editable a[href='#'][name=''],
+.aloha-editable a[href=''][name=''] {
 	background-color: red;
 }


### PR DESCRIPTION
Emptylink-Plugin: The emptylink-plugin would highlight all empty links on the whole page.
This has been fixed now only empty links inside of editables will be hightlighted.