### PR TITLE
dom.js: Fix insertIntoDOM() problem, which can cause a new object not…

### DIFF
--- a/build/changelog/entries/2015/06/10252.SUP-1079.bugfix
+++ b/build/changelog/entries/2015/06/10252.SUP-1079.bugfix
@@ -1,0 +1,2 @@
+﻿A bug with the selection sometimes caused an object not to be inserted into 
+the DOM. The insertion problem has been fixed now.

--- a/src/lib/util/dom.js
+++ b/src/lib/util/dom.js
@@ -1320,6 +1320,11 @@ define(['jquery', 'util/class', 'aloha/ecma5shims'], function (jQuery, Class, $_
 						container = range.endContainer;
 						offset = range.endOffset;
 					}
+					// Sometimes the offset can be greater than the length of the
+					// container contents due to a bug. In that case adjust the offset.
+					if (offset > jQuery(container).contents().length) {
+						offset = jQuery(container).contents().length;
+					}
 					if (offset === 0) {
 						// insert right before the first element in the container
 						contents = jQuery(container).contents();


### PR DESCRIPTION
… to get inserted into the DOM.

The selected range is sometimes incorrect (either a bug in Aloha or IE - so far the problem has only occurred in some versions of IE9). Sometimes the selection offset is greater than 0 even though the container, where the object is to be inserted, does not have any contents. Add a check for that case and append the object to the container in that case.

SUP-1079