### PR TITLE
Attribute Field: Trigger the item-change event also when setItem() is…

### DIFF
--- a/build/changelog/entries/2015/06/10253.SUP-1027.bugfix
+++ b/build/changelog/entries/2015/06/10253.SUP-1027.bugfix
@@ -1,0 +1,7 @@
+﻿A bug with the triggering of the item-change event caused custom sidebar info 
+fields, which have been specified in the settings for the link plugin, to not 
+be set when a link is selected and the sidebar opened afterwards. This has 
+been fixed now by triggering the item-change event also when a null item is 
+selected (that is the selection is changed from an element that has an 
+associated repository browser item to an element that does not have an 
+associated repository browser item).

--- a/src/plugins/common/link/lib/link-plugin.js
+++ b/src/plugins/common/link/lib/link-plugin.js
@@ -473,12 +473,6 @@ define([
 					} else {
 						hrefLangField.disableInput();
 					}
-
-					if (jQuery.isArray(pl.settings.sidebar)) {
-						jQuery.each(pl.settings.sidebar, function () {
-							jQuery(pl.nsSel(this.attr)).text("");
-						});
-					}
 				}
 				
 			} );

--- a/src/plugins/common/ui/lib/port-helper-attribute-field.js
+++ b/src/plugins/common/ui/lib/port-helper-attribute-field.js
@@ -360,11 +360,11 @@ define([
 				resourceValue = v;
 				setAttribute(targetAttribute, item[valueField]);
 				RepositoryManager.markObject(targetObject, item);
-				
-				element.trigger('item-change');
 			} else {
 				resourceValue = null;
 			}
+			
+			element.trigger('item-change');
 		}
 
 		function getItem() {


### PR DESCRIPTION
… called with parameter null.

Triggering the item-change event always, solves a problem with custom sidebar fields of the link plugin, which were not set when a link was selected before the sidebar is opened.

SUP-1027