### PR TITLE
EmptyParagraph plugin: Make the CSS selector of the background-color …

### DIFF
--- a/build/changelog/entries/2015/06/10256.SUP-1044.bugfix
+++ b/build/changelog/entries/2015/06/10256.SUP-1044.bugfix
@@ -1,0 +1,3 @@
+﻿When the metaview and emptyparagraph plugins were used at the same time, the 
+metaview plugin would override the background-color CSS rule of the 
+emptyparagraph plugin. This has been fixed now.

--- a/src/plugins/extra/emptyparagraph/css/emptyparagraph.css
+++ b/src/plugins/extra/emptyparagraph/css/emptyparagraph.css
@@ -1,3 +1,3 @@
-.aloha-empty-element {
+.aloha-editable .aloha-empty-element {
 	background-color: red;
 }


### PR DESCRIPTION
…rule more specific.

This change is necessary, because otherwise when using the metaview plugin at the same time, it would override the background-color set by the emptyparagraph plugin.

SUP-1044