### PR TITLE
Table Plugin: Lost selection in table cell

### DIFF
--- a/build/changelog/entries/2015/06/10263.SUP-1215.changelog
+++ b/build/changelog/entries/2015/06/10263.SUP-1215.changelog
@@ -1,0 +1,1 @@
+When trying to select all text in a table cell, the selection got lost sometimes. This has been fixed.

--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -178,12 +178,19 @@ define([
 			return $wrapper;
 		});
 
-		$elem.bind('mousedown', function ($event) {
+		$elem.bind('mouseup', function ($event) {
 			window.setTimeout(function () {
 				// Select the entire cell's content.
 				cell.wrapper.trigger('focus');
-				cell._selectAll($wrapper);
+				if (cell.tableObj.selection.selectedCells.length <= 1) {
+					if (!(jQuery($event.target).attr("contenteditable") === "true")) {
+						cell._selectAll($wrapper);
+					}
+				}
 			}, 1);
+		});
+
+		$elem.bind('mousedown', function ($event) {
 			cell.tableObj.selection.baseCellPosition = [cell._virtualY(), cell._virtualX()];
 
 			if (!cell.tableObj.selection.lastBaseCellPosition) {


### PR DESCRIPTION
When trying to select all text in a cell the selection got lost if the mouseup event was fired in the cell but outside the contenteditable.
This has been fixed.