### PR TITLE
Emptylink Plugin: Fix incorrect classification of links set by repository browser and href='#'.

### DIFF
--- a/build/changelog/entries/2015/06/10266.SUP-1172.bugfix
+++ b/build/changelog/entries/2015/06/10266.SUP-1172.bugfix
@@ -1,0 +1,4 @@
+﻿When the emptylink plugin was used together with a plugin that would set a
+link's href attribute to '#' after selecting an item from the repository 
+browser, the emptylink plugin would incorrectly classify that link as empty.
+This has been fixed now.

--- a/src/plugins/extra/emptylink/css/emptylink.css
+++ b/src/plugins/extra/emptylink/css/emptylink.css
@@ -1,8 +1,8 @@
 /* mark all anchor elements without name and href attribute */
 .aloha-editable a:not([name]):not([href]),
-/* mark all anchor elements with empty href attribute (including '#') and the name attribute not set */
-.aloha-editable a[href='#']:not([name]),
-.aloha-editable a[href='']:not([name]),
+/* mark all anchor elements with empty href attribute (including '#') and the name and data-gentics-aloha-object-id attributes not set */
+.aloha-editable a[href='#']:not([name]):not([data-gentics-aloha-object-id]),
+.aloha-editable a[href='']:not([name]):not([data-gentics-aloha-object-id]),
 /* mark all anchor elements with empty name attribute and the href attribute not set */
 .aloha-editable a[name='']:not([href]),
 /* mark all anchor elements with empty href (including '#') and empty name attribute */


### PR DESCRIPTION
Some external plugins (e.g. Gentics Content.Node plugins) may set a link's href attribute to '#' after selecting an item from the repository browser, which made the emptylink plugin incorrectly classify such links as empty. Check for the presence of data-gentics-aloha-object-id attribute to fix this.

SUP-1172

Admin please build this request