### PR TITLE
Prevent changing the range in "delete" or "forwarddelete" if nothing is

### DIFF
--- a/build/changelog/entries/2015/06/10267.SUP-1241.bugfix
+++ b/build/changelog/entries/2015/06/10267.SUP-1241.bugfix
@@ -1,0 +1,5 @@
+The behaviour of DELETE and BACKSPACE has been fixed:
+If nothing is deleted, because the next/previous element is a block,
+the current selection is not changed. This fixes problems in Internet Explorer
+where after pressing DELETE when the cursor right before a block, the selection
+would be moved into the block, which prevented further editing.

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -6783,6 +6783,11 @@ define([
 			// start (node, offset − 1) and end (node, offset) and abort these
 			// steps."
 			if (node.nodeType == $_.Node.TEXT_NODE && offset != 0) {
+				// if the place we found is not editable, we stop here
+				if (!isEditable(node)) {
+					return;
+				}
+
 				range.setStart(node, offset - 1);
 				range.setEnd(node, offset - 1);
 				deleteContentsRange = deleteContents(node, offset - 1, node, offset);
@@ -7376,6 +7381,11 @@ define([
 			var endOffset;
 			// "If node is a Text node and offset is not node's length:"
 			if (node.nodeType == $_.Node.TEXT_NODE && offset != getNodeLength(node)) {
+				// if the place we found (which we want to delete) is not editable, we stop here
+				if (!isEditable(node)) {
+					return;
+				}
+
 				// "Call collapse(node, offset) on the Selection."
 				range.setStart(node, offset);
 				range.setEnd(node, offset);


### PR DESCRIPTION
deleted, because the next/previous element is not editable.