### PR TITLE
Do not prevent the aloha-selection-changed* events when clicking on a successor of a nested editable.

### DIFF
--- a/build/changelog/entries/2015/07/10275.SUP-1165.bugfix
+++ b/build/changelog/entries/2015/07/10275.SUP-1165.bugfix
@@ -1,0 +1,3 @@
+When clicking on a nested editable, the selection-changed events where
+not triggered when the actual target of the click was not the editable
+itself (e.g. when clicking on formated text). This has been fixed.

--- a/src/plugins/common/block/lib/block.js
+++ b/src/plugins/common/block/lib/block.js
@@ -262,8 +262,9 @@ define([
 		 * NOTE: Purely internal, "this" is not available inside this method!
 		 */
 		_preventSelectionChangedEventHandler: function ($event) {
-			if (('dblclick' !== $event.type) && 
-				!jQuery($event.target).is('.aloha-editable')) {
+			var $editable = $($event.target).closest('.aloha-editable');
+
+			if ('dblclick' !== $event.type && !this.contains($editable[0])) {
 				Aloha.Selection.preventSelectionChanged();
 			}
 		},


### PR DESCRIPTION
Admin please build this request.