### PR TITLE
emptylink plugin: highlight "http://" href values

### DIFF
--- a/build/changelog/entries/2015/07/10284.SUP-1420.bugfix
+++ b/build/changelog/entries/2015/07/10284.SUP-1420.bugfix
@@ -1,0 +1,2 @@
+The emptylink-plugin will now also highlight links where the value of the href attribute is "http://".
+The reason behind this is that the href value for newly inserted links with the link plugin is "http://" per default.

--- a/doc/guides/source/plugin_emptylink.textile
+++ b/doc/guides/source/plugin_emptylink.textile
@@ -7,4 +7,4 @@ endprologue.
 h3. Functional Description
 
 The Plugin relies on CSS selectors to highlight the empty link elements (see https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors).
-The CSS selector highlights links which its link target attribute ('href') is either '#' or empty.
+The CSS selector highlights links which its link target attribute ('href') is either '#', 'http://' or empty.

--- a/src/plugins/extra/emptylink/css/emptylink.css
+++ b/src/plugins/extra/emptylink/css/emptylink.css
@@ -3,10 +3,12 @@
 /* mark all anchor elements with empty href attribute (including '#') and the name and data-gentics-aloha-object-id attributes not set */
 .aloha-editable a[href='#']:not([name]):not([data-gentics-aloha-object-id]),
 .aloha-editable a[href='']:not([name]):not([data-gentics-aloha-object-id]),
+.aloha-editable a[href='http://']:not([name]):not([data-gentics-aloha-object-id]),
 /* mark all anchor elements with empty name attribute and the href attribute not set */
 .aloha-editable a[name='']:not([href]),
 /* mark all anchor elements with empty href (including '#') and empty name attribute */
 .aloha-editable a[href='#'][name=''],
+.aloha-editable a[href='http://'][name=''],
 .aloha-editable a[href=''][name=''] {
 	background-color: red;
 }


### PR DESCRIPTION
The default value of newly inserted links with the link plugin is "http://". It is now recognized as an empty link.