### PR TITLE
Format plugin: prevent removing paragraphs

### DIFF
--- a/build/changelog/entries/2015/08/10293.SUP-1506.bugfix
+++ b/build/changelog/entries/2015/08/10293.SUP-1506.bugfix
@@ -1,0 +1,2 @@
+The action "Remove formatting" also removed the paragraph around a selection. This has been fixed.
+Now this action only removes html elements that affect the formatting and are expected to be removed.

--- a/src/plugins/common/format/lib/format-plugin.js
+++ b/src/plugins/common/format/lib/format-plugin.js
@@ -904,9 +904,10 @@ define('format/format-plugin', [
 		 */
 		removeFormat: function() {
 			var formats = [
-				'u', 'strong', 'em', 'b', 'i', 'q', 'del', 's', 'code', 'sub', 'sup', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre', 'quote', 'blockquote',
-				'section', 'article', 'aside', 'header', 'footer', 'address', 'main', 'hr', 'figure', 'figcaption', 'div', 'small', 'cite', 'dfn',
-				'abbr', 'data', 'time', 'var', 'samp', 'kbd', 'mark', 'span', 'wbr', 'ins'
+				'u', 'strong', 'em', 'b', 'i', 'q', 'del', 's', 'code', 'sub', 'sup',
+				'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre', 'quote', 'blockquote',
+				'address', 'small', 'cite', 'dfn',
+				'abbr', 'time', 'var', 'samp', 'kbd', 'mark', 'span', 'ins'
 				],
 			    rangeObject = Selection.rangeObject,
 			    i;


### PR DESCRIPTION
When removing the formatting on a selection, the paragraph was also removed. This has been fixed.