### PR TITLE
Trigger aloha-smart-content-changed event of type block-change with a

### DIFF
--- a/build/changelog/entries/2015/08/10294.SUP-1365.bugfix
+++ b/build/changelog/entries/2015/08/10294.SUP-1365.bugfix
@@ -1,0 +1,2 @@
+Initializing an editable containing many blocks could cause long running script
+in the browser, which has been fixed now.

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -1039,15 +1039,21 @@ define([
 				handleSmartContentChange(me);
 
 			} else if (event && event.type === 'block-change') {
-				Aloha.trigger('aloha-smart-content-changed', {
-					'editable': me,
-					'keyIdentifier': null,
-					'keyCode': null,
-					'char': null,
-					'triggerType': 'block-change',
-					'getSnapshotContent': getSnapshotContent
-				});
-				handleSmartContentChange(me);
+				clearTimeout(this.sccTimerIdle);
+				clearTimeout(this.sccTimerDelay);
+
+				this.sccTimerDelay = window.setTimeout(function () {
+					Aloha.trigger('aloha-smart-content-changed', {
+						'editable': me,
+						'keyIdentifier': null,
+						'keyCode': null,
+						'char': null,
+						'triggerType': 'block-change',
+						'getSnapshotContent': getSnapshotContent
+					});
+					handleSmartContentChange(me);
+
+				}, this.sccDelay);
 
 			} else if (uniChar !== null) {
 				// in the rare case idle time is lower then delay time


### PR DESCRIPTION
delay to avoid triggering for every single call.