### PR TITLE
Disable IE11 in-built block resizing

### DIFF
--- a/build/changelog/entries/2015/08/10313.SUP-1526.bugfix
+++ b/build/changelog/entries/2015/08/10313.SUP-1526.bugfix
@@ -1,0 +1,3 @@
+Internet Explorer 11 showed undesired resize handles around block elements.
+Since block elements should not be resized through the browser's in-built
+interface, this has been disabled.

--- a/src/plugins/common/block/lib/block-plugin.js
+++ b/src/plugins/common/block/lib/block-plugin.js
@@ -119,6 +119,17 @@ define([
 			// set the dropzones for the initialized editable
 			Aloha.bind('aloha-editable-created', function (e, editable) {
 				that.setDropzones(editable.obj);
+
+				// Because we don't want non-contentEditable regions inside of
+				// editables to be resizable through the browser-built
+				// interfaces. IE 11 requires this additional muzzling to be
+				// done on the body in order to thoroughly prevent
+				// objectResizing.
+				// @see Block._disableUglyInternetExplorerDragHandles
+				// @see https://connect.microsoft.com/IE/feedback/details/742593/please-respect-execcommand-enableobjectresizing-in-contenteditable-elements
+				editable.obj.on('mscontrolselect', function (event) {
+					event.preventDefault();
+				});
 			});
 
 			// apply specific configuration if an editable has been activated


### PR DESCRIPTION
Prevents undesired resizing of blocks in IE11.