### PR TITLE
Prevent newlines from being pasted into editables

### DIFF
--- a/build/changelog/entries/2015/09/10315.SUP-1634.bugfix
+++ b/build/changelog/entries/2015/09/10315.SUP-1634.bugfix
@@ -1,0 +1,5 @@
+Some content that was pasted in Internet Explorer 11 coming from newer versions
+of Microsoft Word resulted in newlines instead of white space being inserted
+into the editables. These newlines get removed during saving as is required for
+perticular part types resulting in unintended join of words at times.
+This issue has now been fixed.

--- a/src/plugins/common/contenthandler/lib/genericcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/genericcontenthandler.js
@@ -118,6 +118,22 @@ define([
 		);
 	}
 
+	/**
+	 * Replaces unnecessary new line characters within text nodes in Word HTML
+	 * with a space.
+	 *
+	 * @param {jQuery.<HTMLElement>} $content
+	 */
+	function replaceNewlines($content) {
+		$content.contents().each(function (index, node) {
+			if (3 === node.nodeType) {
+				node.nodeValue = node.nodeValue.replace(/[\r\n]+/gm, ' ');
+			} else {
+				replaceNewlines($(node));
+			}
+		});
+	}
+
 	var GenericContentHandler = Manager.createHandler({
 
 		/**
@@ -162,6 +178,8 @@ define([
 			if (transformFormatting) {
 			    this.transformFormattings($content);
 			}
+
+			replaceNewlines($content);
 
 			return $content.html();
 		},

--- a/src/plugins/common/contenthandler/lib/wordcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/wordcontenthandler.js
@@ -160,29 +160,6 @@ define([
 	}
 
 	/**
-	 * Replaces unnecessary new line characters within text nodes in Word HTML 
-	 * with a space.
-	 *
-	 * @param {jQuery.<HTMLElement>} $content
-	 */
-	function replaceWordNewLines($content) {
-		var i;
-		var $nodes = $content.contents();
-		var node;
-
-		for (i = 0; i < $nodes.length; i++) {
-			node = $nodes[i];
-
-			if (3 === node.nodeType) {
-				var text = node.nodeValue;
-				node.nodeValue = text.replace(/[\r\n]+/gm, ' ');
-			} else {
-				replaceWordNewLines($nodes.eq(i));
-			}
-		}
-	}
-
-	/**
 	 * Cleanup MS Word HTML.
 	 *
 	 * @param {jQuery.<HTMLElement>} $content
@@ -252,7 +229,6 @@ define([
 		}
 
 		removeUnrenderedChildNodes($content);
-		replaceWordNewLines($content);
 	}
 
 	/**


### PR DESCRIPTION
Fix problems arising for newlines entering into editables via pasted content from newer versions of MS Word in IE11