### PR TITLE
Fix bug with click handling when using SVGs

### DIFF
--- a/src/dom/classes.js
+++ b/src/dom/classes.js
@@ -67,7 +67,7 @@ define([
 	 * @memberOf dom
 	 */
 	function has(node, value) {
-		return Nodes.isElementNode(node)
+		return Nodes.isElementNode(node) && typeof node.className === 'string'
 		    && node.className.trim().split(Strings.WHITE_SPACES).indexOf(value) >= 0;
 	}
 


### PR DESCRIPTION
Add a check on the has method to make sure that node.className is a string as this isn't the case when the node is an SVG and means click handling breaks as the trim method doesn't exist on the object