### PR TITLE
Fixes #1483 - problems with selection when triple clicking

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -191,7 +191,7 @@ define([
 		});
 		var node = Arrays.last(ancestors);
 		var len = Dom.nodeLength(node);
-		return [Boundaries.create(node, 0), next(Boundaries.create(node, len))];
+		return [Boundaries.create(node, 0), Boundaries.create(node, len)];
 	}
 
 	/**


### PR DESCRIPTION
Not sure what else uses expandToBlock or what the reasoning behind the next() call around the boundary was so this one definitely needs a bit of thought when reviewing. This change does appear to fix both problems outlined in the issue without any visible side affects.