### PR TITLE
Wrap port-helper-attribute-fields target object in a jQuery object before using it.

### DIFF
--- a/build/changelog/entries/2015/12/10438.SUP-2246.bugfix
+++ b/build/changelog/entries/2015/12/10438.SUP-2246.bugfix
@@ -1,0 +1,3 @@
+Several plugins used the port-helper-attribute-field with HTML DOM elements instead of
+jQuery objects resulting in errors like "X.attr() is not a function". This has been
+fixed.

--- a/src/plugins/common/ui/lib/port-helper-attribute-field.js
+++ b/src/plugins/common/ui/lib/port-helper-attribute-field.js
@@ -398,13 +398,14 @@ define([
 		 * @void
 		 */
 		function setTargetObject(obj, attr) {
+			var $obj = $(obj); // Just to be sure, we have a jQuery object.
 			targetObject = obj;
 			targetAttribute = attr;
 			additionalTargetObjects = [];
 			
 			if (obj && attr) {
-				lastAttributeValue = $(obj).attr(attr);
-				setValue($(targetObject).attr(targetAttribute));
+				lastAttributeValue = $obj.attr(attr);
+				setValue(lastAttributeValue);
 
 				setItem(null);
 			} else {
@@ -415,19 +416,19 @@ define([
 				return;
 			}
 
-			var ignoreAutoValues = targetObject.attr('data-ignore-auto-values');
+			var ignoreAutoValues = $obj.attr('data-ignore-auto-values');
 
 			// check whether a repository item is linked to the object
 			RepositoryManager.getObject( obj, function ( items ) {
 				if (items && items.length > 0) {
 					if (ignoreAutoValues) {
-						targetObject.attr('data-ignore-auto-values', ignoreAutoValues);
+						$obj.attr('data-ignore-auto-values', ignoreAutoValues);
 					}
 
 					setItem(items[0]);
 
 					if (ignoreAutoValues) {
-						targetObject.removeAttr('data-ignore-auto-values');
+						$obj.removeAttr('data-ignore-auto-values');
 					}
 				}
 			});


### PR DESCRIPTION
runbuild