### PR TITLE
Fix typo in the german translation of the align plugin.

### DIFF
--- a/build/changelog/entries/2015/12/10448.SUP-2263.bugfix
+++ b/build/changelog/entries/2015/12/10448.SUP-2263.bugfix
@@ -1,0 +1,1 @@
+Fixed a typo in the german translation of the align plugin.

--- a/src/plugins/common/align/nls/de/i18n.js
+++ b/src/plugins/common/align/nls/de/i18n.js
@@ -1,5 +1,5 @@
 define({
-	"button.alignright.tooltip": "Rechtsbünding",
+	"button.alignright.tooltip": "Rechtsbündig",
 	"button.alignleft.tooltip": "Linksbündig",
 	"button.aligncenter.tooltip": "Zentriert",
 	"button.alignjustify.tooltip": "Blocksatz",


### PR DESCRIPTION
runbuild