### PR TITLE
Improve the 'aloha.selection.context-change' pubsub event

### DIFF
--- a/build/changelog/entries/2016/02/10521.SUP-2365.bugfix
+++ b/build/changelog/entries/2016/02/10521.SUP-2365.bugfix
@@ -1,0 +1,2 @@
+When clicking outside of an editable, and clicking inside on the same element again, the 'aloha.selection.context-change' was not triggered, which for example also prevented the link UI from being activated. This has been fixed.
+

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -865,6 +865,8 @@ define([
 			Aloha.activeEditable.smartContentChange({
 				type: 'blur'
 			}, null);
+
+			Selection.resetPrevSelectionContexts();
 		},
 
 		/**

--- a/src/lib/aloha/selection.js
+++ b/src/lib/aloha/selection.js
@@ -2171,6 +2171,14 @@ define([
 		},
 
 		/**
+		 * Sets prevStartContext & prevEndContext to null
+		 */
+		resetPrevSelectionContexts: function () {
+			prevStartContext = null;
+			prevEndContext   = null;
+		},
+
+		/**
 		 * String representation
 		 * @return "Aloha.Selection"
 		 * @hide


### PR DESCRIPTION
It doesn't trigger when clicking outside an editable and clicking on the same previous element again in the editable.