### PR TITLE
Cursor jumps to the wrong place when highlighting text and typing

### DIFF
--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -5586,7 +5586,7 @@ define([
 			// if deleting the text moved two spaces together, we replace the left one by a &nbsp;, which makes the two spaces a visible
 			// two space sequence
 			if (startOffset > 0 && startNode.data.substr(startOffset - 1, 1) === ' ' && startOffset < startNode.data.length && startNode.data.substr(startOffset, 1) === ' ') {
-				startNode.replaceData(startOffset - 1, 1, '\xa0');
+				startNode.replaceData(startOffset, 1, '\xa0');
 			}
 
 			// "Canonicalize whitespace at (start node, start offset)."

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -5586,7 +5586,7 @@ define([
 			// if deleting the text moved two spaces together, we replace the left one by a &nbsp;, which makes the two spaces a visible
 			// two space sequence
 			if (startOffset > 0 && startNode.data.substr(startOffset - 1, 1) === ' ' && startOffset < startNode.data.length && startNode.data.substr(startOffset, 1) === ' ') {
-				startNode.replaceData(startOffset + 1, 1, '\xa0');
+				startNode.replaceData(startOffset - 1, 1, '\xa0');
 			}
 
 			// "Canonicalize whitespace at (start node, start offset)."

--- a/src/lib/aloha/engine.js
+++ b/src/lib/aloha/engine.js
@@ -5586,7 +5586,7 @@ define([
 			// if deleting the text moved two spaces together, we replace the left one by a &nbsp;, which makes the two spaces a visible
 			// two space sequence
 			if (startOffset > 0 && startNode.data.substr(startOffset - 1, 1) === ' ' && startOffset < startNode.data.length && startNode.data.substr(startOffset, 1) === ' ') {
-				startNode.replaceData(startOffset - 1, 1, '\xa0');
+				startNode.replaceData(startOffset + 1, 1, '\xa0');
 			}
 
 			// "Canonicalize whitespace at (start node, start offset)."


### PR DESCRIPTION
# Issue

When highlighting a word and beginning to type in the editor (Chrome & Safari), the editor would delete the whitespace between the word your editing and the word before it.
# Fix

The whitespace was being added at the wrong offset. I just adjusted the code to add the whitespace at the correct offset.
