### PR TITLE
Improve table-plugin guides page

### DIFF
--- a/build/changelog/entries/2016/04/10578.SUP-2607.enhancement
+++ b/build/changelog/entries/2016/04/10578.SUP-2607.enhancement
@@ -1,0 +1,1 @@
+When the table layout options of the table-plugin are used alongside the sanitize content-handler (with it's default configuration) the classes on table, tr and td elements are removed by the content-handler. This behaviour is now documented in the guides page of the table-plugin.

--- a/doc/guides/source/plugin_table.textile
+++ b/doc/guides/source/plugin_table.textile
@@ -122,6 +122,8 @@ Aloha.settings.plugins: {
 };
 </javascript>
 
+NOTE: If the table layout options are used alongside the sanitize-content-handler, make sure that the 'class'-attribute is included in the whitelist of allowed attributes for the elements 'table', 'tr' and 'td'. Without this entries in the sanitize-content-handler's whitelist, the content-handler will per default remove the class attribute from tables, table-rows and table-cells.
+
 h3. Components
 
 * table - insert a table into the content


### PR DESCRIPTION
When the table layout options of the table-plugin are used alongside the sanitize content-handler (with it's default configuration) the classes on table, tr and td elements are removed by the content-handler. This behaviour is now documented in the guides page of the table-plugin.