### PR TITLE
Fix selection after adding a paragraph

### DIFF
--- a/build/changelog/entries/2016/05/10628.SUP-2813.bugfix
+++ b/build/changelog/entries/2016/05/10628.SUP-2813.bugfix
@@ -1,0 +1,3 @@
+After adding a paragraph in Chrome the cursor would jump back before the paragraph as soon as you type a character.
+This has been fixed.
+

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -1062,11 +1062,15 @@ define([
 			} else if (uniChar !== null) {
 				var range = Aloha.Selection.getRangeObject();
 
-				if (range.startContainer == range.endContainer) {
-					var $children = $(range.startContainer).children();
+				//Remove break in otherwise empty children in IE and Mozilla
+				//This is done automatically in Chrome and would lead to errors
+				if (Browser.ie || Browser.mozilla) {
+					if (range.startContainer == range.endContainer) {
+						var $children = $(range.startContainer).children();
 
-					if ($children.length == 1 && $children.is('br')) {
-						$children.remove();
+						if ($children.length == 1 && $children.is('br')) {
+							$children.remove();
+						}
 					}
 				}
 


### PR DESCRIPTION
After adding a paragraph the cursor would jump back before the paragraph as soon as you type a character. This has been fixed.