### PR TITLE
Fix missing repository meta data on multi-line links

### DIFF
--- a/src/plugins/common/ui/lib/port-helper-attribute-field.js
+++ b/src/plugins/common/ui/lib/port-helper-attribute-field.js
@@ -359,7 +359,9 @@ define([
 				// store the value to be the "reference" value for the currently selected resource item
 				resourceValue = v;
 				setAttribute(targetAttribute, item[valueField]);
-				RepositoryManager.markObject(targetObject, item);
+				executeForTargets(function (target) {
+					RepositoryManager.markObject(target, item);
+				});
 			} else {
 				resourceValue = null;
 			}


### PR DESCRIPTION
Add repository meta data to all targets when setting a link value to a link repository value on a multi-line link.

fixes #1525