### PR TITLE
Fix formatless paste contenthandler returning undefined

### DIFF
--- a/build/changelog/entries/2016/07/11001.SUP-3149.bugfix
+++ b/build/changelog/entries/2016/07/11001.SUP-3149.bugfix
@@ -1,0 +1,2 @@
+When an inserted content contained an aloha-block the formatless paste handler returned "undefined" instead of the unmodified content. This was causing errors and interrupting the content handler execution chain. This has been fixed.
+

--- a/src/plugins/extra/formatlesspaste/lib/formatlesshandler.js
+++ b/src/plugins/extra/formatlesspaste/lib/formatlesshandler.js
@@ -86,7 +86,7 @@ define([
 			// should be modified as it most probably comes from Aloha and does
 			// not need to be cleaned up.
 			if ($content.find('.aloha-block').length) {
-				return;
+				return content;
 			}
 
 			if (this.enabled) {


### PR DESCRIPTION
A contenthandler should either return modified or unmodified content, but not 'undefined' or it will break the contenthandler execution chain.