### PR TITLE
list-plugin: remove classes when transforming lists

### DIFF
--- a/build/changelog/entries/2016/08/11003.SUP-3171.bugfix
+++ b/build/changelog/entries/2016/08/11003.SUP-3171.bugfix
@@ -1,0 +1,2 @@
+list-plugin: When transforming a list to different list type, the available classes of the old list type where not removed. This has been fixed.
+

--- a/src/lib/aloha/core.js
+++ b/src/lib/aloha/core.js
@@ -72,7 +72,6 @@ define([
 		return $($event.target).closest('.aloha-dialog').length > 0;
 	}
 
-	
 	/**
 	 * Checks whether the given jQuery event originates from a jQuery UI
 	 * element.

--- a/src/plugins/common/list/lib/list-plugin.js
+++ b/src/plugins/common/list/lib/list-plugin.js
@@ -718,6 +718,14 @@ define([
 			// check the dom object
 			nodeName = domToTransform.nodeName.toLowerCase();
 
+			//remove all classes on list type change
+			if (nodeName !== listtype && this.templates[nodeName]) {
+				jqList = jQuery(domToTransform);
+				jQuery.each(this.templates[nodeName].classes, function (i, cssClass) {
+					jqList.removeClass(cssClass);
+				});
+			}
+
 			if (nodeName === listtype) {
 				jqList = jQuery(domToTransform);
 				jqParentList = jqList.parent();
@@ -733,10 +741,10 @@ define([
 					}
 				}
 
-			} else if (nodeName == 'ul' && listtype === 'ol') {
+			} else if (nodeName === 'ul' && listtype === 'ol') {
 				transformExistingListAndSubLists(domToTransform, 'ol');
 				this.mergeAdjacentLists(jQuery(domToTransform));
-			} else if (nodeName == 'ol' && listtype === 'ul') {
+			} else if (nodeName === 'ol' && listtype === 'ul') {
 				transformExistingListAndSubLists(domToTransform, 'ul');
 				this.mergeAdjacentLists(jQuery(domToTransform));
 			} else if (nodeName === 'ul' && listtype === 'dl') {


### PR DESCRIPTION
When transforming an existing list to a different list type, the available classes of the previous list type where not removed.
This has been fixed.
SUP-3171