### PR TITLE
Fix vanishing paragraphs in firefox

### DIFF
--- a/build/changelog/entries/2016/08/11032.SUP-3250.bugfix
+++ b/build/changelog/entries/2016/08/11032.SUP-3250.bugfix
@@ -1,0 +1,2 @@
+Moving over empty paragraphs with the error keys would make the paragraph vanish. This happened only with firefox. This has been fixed.
+

--- a/src/lib/aloha/editable.js
+++ b/src/lib/aloha/editable.js
@@ -1062,9 +1062,9 @@ define([
 			} else if (uniChar !== null) {
 				var range = Aloha.Selection.getRangeObject();
 
-				//Remove break in otherwise empty children in IE and Mozilla
+				//Remove break in otherwise empty children in IE
 				//This is done automatically in Chrome and would lead to errors
-				if (Browser.ie || Browser.mozilla) {
+				if (Browser.ie) {
 					if (range.startContainer == range.endContainer) {
 						var $children = $(range.startContainer).children();
 


### PR DESCRIPTION
When moving over empty paragraphs with the arrow keys the paragraphs became invisible, because the <br> placeholder inside the paragraphs was removed. This has been fixed.