### PR TITLE
Fix automatic tab selection upon scope change to check for visibility of

### DIFF
--- a/build/changelog/entries/2016/10/11181.SUP-3284.bugfix
+++ b/build/changelog/entries/2016/10/11181.SUP-3284.bugfix
@@ -1,0 +1,4 @@
+The automatic tab selection of the toolbar upon scope change failed to check whether
+the tab to be selected contained any visible children. This could cause the toolbar to
+appear empty (with none of the visible tabs selected).
+This has been fixed now.

--- a/src/plugins/common/ui/lib/ui-plugin.js
+++ b/src/plugins/common/ui/lib/ui-plugin.js
@@ -92,7 +92,7 @@ define('ui/ui-plugin', [
 		    i;
 		for (i = 0; i < tabs.length; i++) {
 			settings = tabs[i].settings;
-			if ('object' === $.type(settings.showOn) && settings.showOn.scope === primaryScope) {
+			if ('object' === $.type(settings.showOn) && settings.showOn.scope === primaryScope && tabs[i].tab.hasVisibleComponents()) {
 				tabs[i].tab.foreground();
 				break;
 			}


### PR DESCRIPTION
the tabs.