### PR TITLE
Add workaround for IE problem with links in table cells or in editables

### DIFF
--- a/build/changelog/entries/2016/10/11226.SUP-3459.bugfix
+++ b/build/changelog/entries/2016/10/11226.SUP-3459.bugfix
@@ -1,0 +1,2 @@
+When using Internet Explorer, links in table cells or in editables nested inside blocks where not clickable.
+This has been fixed now.

--- a/src/plugins/common/block/lib/block.js
+++ b/src/plugins/common/block/lib/block.js
@@ -158,7 +158,9 @@ define([
 				$element.find('img').attr('draggable', 'false');
 
 				try {
-					$element.find('a').attr('draggable', 'false');
+					$element.find('a').filter(function () {
+						return !jQuery(this).contentEditable();
+					}).attr('draggable', 'false');
 				} catch (e) {
 					// If we get in here, it is most likely an issue with IE 10 in documentmode 7
 					// and IE10 compatibility mode. It maybe happens in older versions too.
@@ -166,7 +168,9 @@ define([
 					// https://connect.microsoft.com/IE/feedback/details/774078
 					// http://bugs.jquery.com/ticket/12577
 					// Our fallback solution:
-					$element.find('a').each(function () {
+					$element.find('a').filter(function () {
+						return !jQuery(this).contentEditable();
+					}).each(function () {
 						this.setAttribute('draggable', 'false');
 					});
 				}

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -606,12 +606,6 @@ define([
 		// wrap the tableWrapper around the table
 		this.obj.wrap( tableWrapper );
 
-		// Check because the aloha block plugin may not be loaded
-		var parent = this.obj.parent();
-		if (parent.alohaBlock) {
-			parent.alohaBlock();
-		}
-
 		// :HINT The outest div (Editable) of the table is still in an editable
 		// div. So IE will surround the the wrapper div with a resize-border
 		// Workaround => just disable the handles so hopefully won't happen any ugly stuff.
@@ -632,6 +626,15 @@ define([
 		jQuery( this.cells ).each( function () {
 			this.activate();
 		} );
+
+		// Check because the aloha block plugin may not be loaded
+		// This is done, after the cells were made contenteditable, so that while initialization of the block,
+		// contenteditable anchors do not get the attribute 'draggable' set to 'false' (in order to prevent browser drag'n'drop)
+		// because this would make the anchors unclickable in IE
+		var parent = this.obj.parent();
+		if (parent.alohaBlock) {
+			parent.alohaBlock();
+		}
 
 		// after the cells where replaced with contentEditables ... add selection cells
 		// first add the additional columns on the left side


### PR DESCRIPTION
nested inside blocks: Do not set attribute 'draggable' to 'false', since
links would not be clickable any more.