### PR TITLE
Fix detecting the checkHeadingHierarchy setting

### DIFF
--- a/build/changelog/entries/2016/10/11277.SUP-3500.bugfix
+++ b/build/changelog/entries/2016/10/11277.SUP-3500.bugfix
@@ -1,0 +1,3 @@
+When changing a heading with the format plugin the check, whether the heading hierarchy is violated, did not work for some configurations.
+This has been fixed.
+

--- a/src/plugins/common/format/lib/format-plugin.js
+++ b/src/plugins/common/format/lib/format-plugin.js
@@ -424,7 +424,7 @@ define('format/format-plugin', [
 
 	function changeMarkup(button) {
 		Selection.changeMarkupOnSelection(jQuery('<' + button + '>'));
-		if (Aloha.settings.plugins.format && Aloha.settings.plugins.format.checkHeadingHierarchy === true) {
+		if (Aloha.settings.plugins.format && Aloha.settings.plugins.format.checkHeadingHierarchy) {
 			checkHeadingHierarchy(this.formatOptions);
 		}
 	}


### PR DESCRIPTION
The check if the checkHeadingHierarchy feature is activated was way too strict.