### PR TITLE
SUP-3537 configurable wrapping div with class for table

### DIFF
--- a/build/changelog/entries/2016/11/11291.SUP-3537.feature
+++ b/build/changelog/entries/2016/11/11291.SUP-3537.feature
@@ -1,16 +1,16 @@
-h2. added wrapping div element for tables for responsive tables
+*added configurable wrapping div element for tables*
 
 Create responsive tables by wrapping table-elements created by Aloha-Editor in a div-element with a configurable class to make them scroll horizontally on small devices.
 This follows the example giving by "Twitter Bootstrap":http://getbootstrap.com/css/#tables-responsive
 
-h3. Configuration Example
+*Configuration Example*
 
 <pre>
 // enable the wrapping div-element and set the class to 'responsive-table'
-table.settings.wrapClass = 'responsive-table';
+Aloha.settings.plugins.table.wrapClass = 'responsive-table';
 </pre>
 
-h3. Output Example
+*Output Example*
 
 <pre>
 <div class="responsive-table">

--- a/build/changelog/entries/2016/11/11291.SUP-3537.feature
+++ b/build/changelog/entries/2016/11/11291.SUP-3537.feature
@@ -1,0 +1,21 @@
+h2. added wrapping div element for tables for responsive tables
+
+Create responsive tables by wrapping table-elements created by Aloha-Editor in a div-element with a configurable class to make them scroll horizontally on small devices.
+This follows the example giving by "Twitter Bootstrap":http://getbootstrap.com/css/#tables-responsive
+
+h3. Configuration Example
+
+<pre>
+// enable the wrapping div-element and set the class to 'responsive-table'
+table.settings.wrapClass = 'responsive-table';
+</pre>
+
+h3. Output Example
+
+<pre>
+<div class="responsive-table">
+    <table>
+        ...
+    </table>
+</div>
+</pre>

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -115,12 +115,29 @@ define([
 		this.obj = jQuery( table );
 
 		// check config if table should be wrapped
-		if( tablePlugin.settings.wrapClass !== undefined ) {
-			// add div with class from config
-			this.obj.wrap('<div class="' + tablePlugin.settings.wrapClass + '"></div>');
+		if ( tablePlugin.settings.wrapClass !== undefined ) {
+			// If config for wrapping div exists and classes match, do nothing
+			if ( this.obj.parent().attr('class') === tablePlugin.settings.wrapClass ) {
+				// do nothing with wrapper (allready there)
+			// If config for wrapping div exists and classes do not match, change classes
+			// check if there is a wrapper by checking for aloha-editable as parent
+			// a table element as a direct child of aloha-editable does not have a wrapper
+			} else if ( this.obj.parent().attr('class') !== tablePlugin.settings.wrapClass && ! this.obj.parent().hasClass('aloha-editable')) {
+				this.obj.parent().attr('class', tablePlugin.settings.wrapClass);
+
+			// If config for wrapping div exists but div is not present yet, create
+			// the wrapping div is not present when the parent of the table is the .aloha-editable
+			} else if ( this.obj.parent().hasClass('aloha-editable') ) {
+				// add div with class from config
+				this.obj.wrap('<div class="' + tablePlugin.settings.wrapClass + '"></div>');
+			}
 			// set wrappedObj for further handling
 			this.wrappedObj = this.obj.parent();
 		} else {
+			// If config for wrapping div does not exists but there is a wrapping div, remove it
+			if ( ! this.obj.parent().hasClass('aloha-editable') ) {
+				this.obj.unwrap();
+			}
 			// set table-element itself for further handling
 			this.wrappedObj = this.obj;
 		}
@@ -537,12 +554,12 @@ define([
 					var row = cell.closest( 'tr');
 					// check if it's the last row
 					if ( row.next( 'tr').length > 0 ) {
-						return false
+						return false;
 					}
 
 					var cursorOffset = e.pageY - ( row.offset().top + row.outerHeight() );
 					return cursorOffset > (mouseOffset * -1) && cursorOffset < mouseOffset;
-				}
+				};
 
 				var colResize = that.tablePlugin.colResize;
 				var rowResize = that.tablePlugin.rowResize;
@@ -625,7 +642,7 @@ define([
 		// were created dynamically before) ;)
 
 		htmlTableWrapper = this.obj.parents( '.' + this.get( 'classTableWrapper' ) );
-        htmlTableWrapperElem = this.obj.parents( '.' + this.get( 'classTableWrapper' ) ).get( 0 );
+		htmlTableWrapperElem = this.obj.parents( '.' + this.get( 'classTableWrapper' ) ).get( 0 );
 		htmlTableWrapperElem.onresizestart = function ( e ) { return false; };
 		htmlTableWrapperElem.oncontrolselect = function ( e ) { return false; };
 		htmlTableWrapperElem.ondragstart = function ( e ) { return false; };
@@ -919,7 +936,7 @@ define([
 				curNumColumns += colspan;
 			}
 
-			if( numColumns < curNumColumns ) {
+			if ( numColumns < curNumColumns ) {
 				numColumns = curNumColumns;
 			}
 		}

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -144,7 +144,6 @@ define([
 		} else {
 			// If config for wrapping div does not exists
 			// and there is a wrapping div
-			// and their is only one child of the parent (expected default behaviour - no interfernce by other markup altering plugins)
 			// --> remove it
 			if ( parent.hasClass( wrapperMarkerClass ) ) {
 				this.obj.unwrap();

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -146,7 +146,7 @@ define([
 			// and there is a wrapping div
 			// and their is only one child of the parent (expected default behaviour - no interfernce by other markup altering plugins)
 			// --> remove it
-			if ( parent.hasClass( wrapperMarkerClass ) && parent.find(':only-child' ).length === 1 ) {
+			if ( parent.hasClass( wrapperMarkerClass ) ) {
 				this.obj.unwrap();
 			}
 			// set table-element itself for further handling

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -43,9 +43,9 @@ define([
 	var GENTICS = window.GENTICS;
 
 	/**
-	 * Returns an Array with all elements and textnodes included in the 
-	 * hierarchy of the element received. Is Similar to do 
-	 * jQuery('*', element).contents(), the diference it's this function returns the 
+	 * Returns an Array with all elements and textnodes included in the
+	 * hierarchy of the element received. Is Similar to do
+	 * jQuery('*', element).contents(), the diference it's this function returns the
 	 * array in the correct order of apparition
 	 * @example
 	 * <pre>
@@ -54,13 +54,13 @@ define([
 	 *			<b>b textnode</b>
 	 *			another text node
 	 *		&gt;/p&lt;
-	 *		
+	 *
 	 *		jQuery('*', lt).contents();
 	 *			// returns ["textnode", "<b>", "another textnode", "b textnode"]
 	 *		getPlainHierarchy(lt)
 	 *			// returns ["textnode", "<b>", "b textnode", "another textnode"]
 	 * </pre>
-	 * 
+	 *
 	 * @return {Array.<HTMLElement|TextNode>}
 	 */
 	function getPlainHierarchy(element) {
@@ -81,10 +81,10 @@ define([
 
 	/**
 	 * Find the first or the last element inside a table, even if in a td
-	 * 
+	 *
 	 * @param {String} type Accepts two values: 'first' or 'last'
 	 * @param {HTMLElement|jQuery} parent the parent element to search
-	 * 
+	 *
 	 * @return {jQuery}
 	 */
 	function getNewSelectedElement(type, parent) {
@@ -113,6 +113,17 @@ define([
 	var Table = function ( table, tablePlugin ) {
 		// set the table attribut "obj" as a jquery represenation of the dom-table
 		this.obj = jQuery( table );
+
+		// check config if table should be wrapped
+		if( tablePlugin.settings.wrapClass !== undefined ) {
+			// add div with class from config
+			this.obj.wrap('<div class="' + tablePlugin.settings.wrapClass + '"></div>');
+			// set wrappedObj for further handling
+			this.wrappedObj = this.obj.parent();
+		} else {
+			// set table-element itself for further handling
+			this.wrappedObj = this.obj;
+		}
 
 		correctTableStructure( this );
 
@@ -604,7 +615,7 @@ define([
 		Ephemera.markWrapper(tableWrapper);
 
 		// wrap the tableWrapper around the table
-		this.obj.wrap( tableWrapper );
+		this.wrappedObj.wrap( tableWrapper );
 
 		// :HINT The outest div (Editable) of the table is still in an editable
 		// div. So IE will surround the the wrapper div with a resize-border
@@ -614,14 +625,13 @@ define([
 		// were created dynamically before) ;)
 
 		htmlTableWrapper = this.obj.parents( '.' + this.get( 'classTableWrapper' ) );
-		htmlTableWrapper.get( 0 ).onresizestart = function ( e ) { return false; };
-		htmlTableWrapper.get( 0 ).oncontrolselect = function ( e ) { return false; };
-		htmlTableWrapper.get( 0 ).ondragstart = function ( e ) { return false; };
-		htmlTableWrapper.get( 0 ).onmovestart = function ( e ) { return false; };
+        htmlTableWrapperElem = this.obj.parents( '.' + this.get( 'classTableWrapper' ) ).get( 0 );
+		htmlTableWrapperElem.onresizestart = function ( e ) { return false; };
+		htmlTableWrapperElem.oncontrolselect = function ( e ) { return false; };
+		htmlTableWrapperElem.ondragstart = function ( e ) { return false; };
+		htmlTableWrapperElem.onmovestart = function ( e ) { return false; };
 		// the following handler prevents proper selection in the editable div in the caption!
-		// htmlTableWrapper.get( 0 ).onselectstart = function ( e ) { return false; };
-
-		this.tableWrapper = this.obj.parents( '.' + this.get( 'classTableWrapper' ) ).get( 0 );
+		// htmlTableWrapperElem.onselectstart = function ( e ) { return false; };
 
 		jQuery( this.cells ).each( function () {
 			this.activate();
@@ -631,9 +641,8 @@ define([
 		// This is done, after the cells were made contenteditable, so that while initialization of the block,
 		// contenteditable anchors do not get the attribute 'draggable' set to 'false' (in order to prevent browser drag'n'drop)
 		// because this would make the anchors unclickable in IE
-		var parent = this.obj.parent();
-		if (parent.alohaBlock) {
-			parent.alohaBlock();
+		if (htmlTableWrapper.alohaBlock) {
+			htmlTableWrapper.alohaBlock();
 		}
 
 		// after the cells where replaced with contentEditables ... add selection cells
@@ -1227,8 +1236,8 @@ define([
 		var selectedColumnIdxs = this.selection.selectedColumnIdxs;
 		// if at least on whole table column was selected using cell selection
 		// it should also be possible to delete the column
-		// therefore we need to determine which columns are selected using the 
-		// current rectangle 
+		// therefore we need to determine which columns are selected using the
+		// current rectangle
 		if (
 			(!selectedColumnIdxs || selectedColumnIdxs.length === 0) &&
 			// check if the current rectangle is active
@@ -1267,7 +1276,7 @@ define([
 			//x-index is selected and deleted.
 
 			//sorted so we delete from right to left to minimize interfernce of deleted rows
-			
+
 			var gridColumns = selectedColumnIdxs.sort(function(a,b){ return b - a; });
 			for (var i = 0; i < gridColumns.length; i++) {
 				var gridColumn = gridColumns[i];
@@ -1724,21 +1733,21 @@ define([
 	 */
 	Table.prototype.deactivate = function() {
 		// unblockify the table wrapper
-		var parent = this.obj.parent();
+		var parent = this.wrappedObj.parent();
 		if (parent.mahaloBlock) {
 			parent.mahaloBlock();
 		}
 
 		this.obj.removeClass(this.get('className'));
-		if (jQuery.trim(this.obj.attr('class')) == '') {
+		if (jQuery.trim(this.obj.attr('class')) === '') {
 			this.obj.removeAttr('class');
 		}
 		this.obj.removeAttr('contenteditable');
 	//	this.obj.removeAttr('id');
 
 		// unwrap the selectionLeft-div if available
-		if (this.obj.parents('.' + this.get('classTableWrapper')).length){
-			this.obj.unwrap();
+		if (this.wrappedObj.parents('.' + this.get('classTableWrapper')).length){
+			this.wrappedObj.unwrap();
 		}
 
 		// remove the selection row

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -303,7 +303,7 @@ define([
 
 			colSpan = parseInt( cols.last().attr( 'colspan' ), 10 );
 
-			if ( colSpan == 0 ) {
+			if ( colSpan === 0 ) {
 				// TODO: support colspan=0
 				// http://dev.w3.org/html5/markup/td.html#td.attrs.colspan
 				// http://www.w3.org/TR/html401/struct/tables.html#adef-colspan
@@ -349,7 +349,7 @@ define([
 				);
 			}
 		}
-	};
+	}
 
 	/**
 	 * If all of the selected cells have been set to the same predefined style,
@@ -442,7 +442,7 @@ define([
 		this.obj.contentEditable( false );
 
 		// set an id to the table if not already set
-		if ( this.obj.attr( 'id' ) == '' ) {
+		if ( this.obj.attr( 'id' ) === '' ) {
 			this.obj.attr( 'id', GENTICS.Utils.guid() );
 		}
 
@@ -803,7 +803,7 @@ define([
 		this.focus();
 
 		// if no cells are selected, reset the selection-array
-		if ( this.selection.selectedCells.length == 0 ) {
+		if ( this.selection.selectedCells.length === 0 ) {
 			this.rowsToSelect = [];
 		}
 
@@ -875,7 +875,7 @@ define([
 			start = (rowIndex < this.clickedRowId) ? rowIndex : this.clickedRowId;
 			end = (rowIndex < this.clickedRowId) ? this.clickedRowId : rowIndex;
 
-			this.rowsToSelect = new Array();
+			this.rowsToSelect = [];
 			for ( i = start; i <= end; i++) {
 				this.rowsToSelect.push(i);
 			}
@@ -941,7 +941,7 @@ define([
 				this.attachColumnSelectEventsToCell(columnToInsert);
 				//set the colspan of selection column to match the colspan of first row columns
 			} else {
-				var columnToInsert = jQuery('<td>').clone();
+				columnToInsert = jQuery('<td>').clone();
 				columnToInsert.addClass(this.get('classLeftUpperCorner'));
 				var clickHandler = function (e) {
 					// select the Table
@@ -1031,7 +1031,7 @@ define([
 		this.focus();
 
 		// if no cells are selected, reset the selection-array
-		if ( this.selection.selectedCells.length == 0 ) {
+		if ( this.selection.selectedCells.length === 0 ) {
 			this.columnsToSelect = [];
 		}
 
@@ -1140,7 +1140,7 @@ define([
 			rowsToDelete[this.selection.selectedCells[i].parentNode.rowIndex] = true;
 		}
 
-	    for (rowId in rowsToDelete) {
+	    for (var rowId in rowsToDelete) {
 	       rowIDs.push(rowId);
 	    }
 
@@ -1281,7 +1281,7 @@ define([
 			for (var i = 0; i < gridColumns.length; i++) {
 				var gridColumn = gridColumns[i];
 				for (var j = 0; j < rows.length; j++) {
-					var cellInfo = grid[j][gridColumn];
+					cellInfo = grid[j][gridColumn];
 					if ( ! cellInfo ) {
 						//TODO this case occurred because of a bug somewhere which should be fixed
 						continue;
@@ -1341,19 +1341,20 @@ define([
 			// we will set the cursor right before the removed table
 			var newRange = Aloha.Selection.rangeObject;
 			// TODO set the correct range here (cursor shall be right before the removed table)
-			newRange.endContainer = this.obj.get(0).parentNode;
+			newRange.endContainer = this.wrappedObj.get(0).parentNode;
 			newRange.startContainer = newRange.endContainer;
 
-			newRange.endOffset = Dom.getIndexInParent(this.obj.get(0));
+			newRange.endOffset = Dom.getIndexInParent(this.wrappedObj.get(0));
 			newRange.startOffset = newRange.endOffset;
 
 			newRange.clearCaches();
 
-			this.obj.remove();
+			this.wrappedObj.remove();
 
+			var that = this;
 			// IE needs a timeout to work properly
 			window.setTimeout( function() {
-				this.parentEditable.obj.focus();
+				that.parentEditable.obj.focus();
 			}, 5);
 
 			// select the new range
@@ -1543,7 +1544,7 @@ define([
 			cell.html( '\u00a0' );
 
 			// on first row correct the position of the selected columns
-			if ( i == 0 ) {
+			if ( i === 0 ) {
 				// this is the first row, so make a column-selection cell
 				this.attachColumnSelectEventsToCell( cell );
 			} else {
@@ -1553,7 +1554,7 @@ define([
 			}
 
 			var leftCell = Utils.leftDomCell( grid, i, currentColIdx );
-			if ( null == leftCell ) {
+			if ( null === leftCell ) {
 				jQuery( rows[i] ).prepend( cell );
 			} else {
 				if ( 'left' === position && Utils.containsDomCell( grid[ i ][ currentColIdx ] ) ) {
@@ -1642,12 +1643,12 @@ define([
 
 		if ( !selection ||
 				!selection._nativeSelection ||
-					selection._nativeSelection._ranges.length == 0 ) {
+					selection._nativeSelection._ranges.length === 0 ) {
 			return;
 		}
 
 		var range = selection.getRangeAt( 0 );
-		if ( null == range.startContainer ) {
+		if ( null === range.startContainer ) {
 			return;
 		}
 
@@ -1664,7 +1665,7 @@ define([
 		// set the foces to the first selected cell
 		var container = TableCell.getContainer( this.selection.selectedCells[ 0 ] );
 		jQuery( container ).focus();
-	}
+	};
 
 	/**
 	 * Marks all cells of the specified column as marked (adds a special class)

--- a/src/plugins/common/table/lib/table.js
+++ b/src/plugins/common/table/lib/table.js
@@ -114,28 +114,39 @@ define([
 		// set the table attribut "obj" as a jquery represenation of the dom-table
 		this.obj = jQuery( table );
 
+		// setup a class to mark wrapping divs introduced by this plugin
+		var wrapperMarkerClass = "aloha-table-container";
+		// parent before wrapping
+		var parent = this.obj.parent();
 		// check config if table should be wrapped
 		if ( tablePlugin.settings.wrapClass !== undefined ) {
-			// If config for wrapping div exists and classes match, do nothing
-			if ( this.obj.parent().attr('class') === tablePlugin.settings.wrapClass ) {
-				// do nothing with wrapper (allready there)
-			// If config for wrapping div exists and classes do not match, change classes
-			// check if there is a wrapper by checking for aloha-editable as parent
-			// a table element as a direct child of aloha-editable does not have a wrapper
-			} else if ( this.obj.parent().attr('class') !== tablePlugin.settings.wrapClass && ! this.obj.parent().hasClass('aloha-editable')) {
-				this.obj.parent().attr('class', tablePlugin.settings.wrapClass);
+			// combine configurable class with fixed
+			var wrapClass = tablePlugin.settings.wrapClass + ' ' + wrapperMarkerClass;
 
-			// If config for wrapping div exists but div is not present yet, create
-			// the wrapping div is not present when the parent of the table is the .aloha-editable
-			} else if ( this.obj.parent().hasClass('aloha-editable') ) {
+			// If config for wrapping div exists and classes match, do nothing
+
+			// If config for wrapping div exists,
+			// and classes do not match,
+			// and a wrapping div does exist allready,
+			// --> change classes
+			if ( parent.attr( 'class' ) !==  wrapClass && parent.hasClass( wrapperMarkerClass ) ) {
+				parent.attr('class', wrapClass);
+			// If config for wrapping div exists
+			// and classes do not match
+			// and wrapping div is not present (yet),
+			// --> create
+			} else if ( parent.attr( 'class')  !==  wrapClass ) {
 				// add div with class from config
-				this.obj.wrap('<div class="' + tablePlugin.settings.wrapClass + '"></div>');
+				this.obj.wrap( '<div class="' + wrapClass + '"></div>' );
 			}
-			// set wrappedObj for further handling
+			// set parent of table element - the wrapping div - for further handling
 			this.wrappedObj = this.obj.parent();
 		} else {
-			// If config for wrapping div does not exists but there is a wrapping div, remove it
-			if ( ! this.obj.parent().hasClass('aloha-editable') ) {
+			// If config for wrapping div does not exists
+			// and there is a wrapping div
+			// and their is only one child of the parent (expected default behaviour - no interfernce by other markup altering plugins)
+			// --> remove it
+			if ( parent.hasClass( wrapperMarkerClass ) && parent.find(':only-child' ).length === 1 ) {
 				this.obj.unwrap();
 			}
 			// set table-element itself for further handling


### PR DESCRIPTION
# added wrapping div element for tables for responsive tables

Create responsive tables by wrapping table-elements created by Aloha-Editor in a div-element with a configurable class to make them scroll horizontally on small devices.
This follows the example giving by "Twitter Bootstrap": http://getbootstrap.com/css/#tables-responsive

## Configuration Example

```
// enable the wrapping div-element and set the class to 'responsive-table'
table.settings.wrapClass = 'responsive-table';

```

## Output Example

```
<div class="responsive-table">
    <table>
        ...
    </table>
</div>
```