### PR TITLE
Removed feature detection for multiple ranges in rangy

### DIFF
--- a/build/changelog/entries/2017/03/11627.SUP-3998.bugfix
+++ b/build/changelog/entries/2017/03/11627.SUP-3998.bugfix
@@ -1,0 +1,3 @@
+Feature detection for selection of multiple ranges in rangy-core caused a deprecation warning in Chrome. Since selection
+of multiple ranges is only available in FireFox and is not supported in Aloha-Editor, detecting this feature has been
+removed altogether.

--- a/src/lib/vendor/rangy-core.js
+++ b/src/lib/vendor/rangy-core.js
@@ -2599,24 +2599,16 @@
 				collapsedNonEditableSelectionsSupported = (sel.rangeCount == 1);
 				sel.removeAllRanges();
 
-				// Test whether the native selection is capable of supporting multiple ranges
-				var r2 = r1.cloneRange();
-				r1.setStart(textNode, 0);
-				r2.setEnd(textNode, 2);
-				sel.addRange(r1);
-				sel.addRange(r2);
-
-				selectionSupportsMultipleRanges = (sel.rangeCount == 2);
-
 				// Clean up
 				r1.detach();
-				r2.detach();
 
 				body.removeChild(iframe);
 			})();
 		}
 
-		api.features.selectionSupportsMultipleRanges = selectionSupportsMultipleRanges;
+		// set the selection support for multiple ranges to false since this feature is only
+		// supported by FireFox and would require extra effort to get it to work in Aloha-Editor
+		api.features.selectionSupportsMultipleRanges = false;
 		api.features.collapsedNonEditableSelectionsSupported = collapsedNonEditableSelectionsSupported;
 
 		// ControlRanges


### PR DESCRIPTION
Feature detection for selection of multiple ranges in rangy-core caused a deprecation warning in Chrome. Since selection of multiple ranges is only available in FireFox and is not supported in Aloha-Editor, detecting this feature has been removed altogether.