### PR TITLE
Fix unchecked access of non-standard window.event object

### DIFF
--- a/build/changelog/entries/2017/03/11629.SUP-4001.bugfix
+++ b/build/changelog/entries/2017/03/11629.SUP-4001.bugfix
@@ -1,3 +1,3 @@
 In Firefox clicking into a table cell sometimes threw an error because a property on the non-standard window.event
-object was accessed. This has bee fixed the Aloha-Editor table plugin will now always use the event object passed to
+object was accessed. This has been fixed. The Aloha-Editor table plugin will now always use the event object passed to
 the event handler by the browser.

--- a/build/changelog/entries/2017/03/11629.SUP-4001.bugfix
+++ b/build/changelog/entries/2017/03/11629.SUP-4001.bugfix
@@ -1,0 +1,3 @@
+In Firefox clicking into a table cell sometimes threw an error because a property on the non-standard window.event
+object was accessed. This has bee fixed the Aloha-Editor table plugin will now always use the event object passed to
+the event handler by the browser.

--- a/src/lib/util/misc.js
+++ b/src/lib/util/misc.js
@@ -117,10 +117,47 @@ define([
 		});
 	}
 
+	/**
+	 * Stops the propagation of an Event (cancel bubble) in a backward compatible way.
+	 * This method tries to first call stopPropagation() on the event object and has a
+	 * fallback which sets the cancelBubble property to true (either on the event
+	 * itself or the or the current window.event object)
+	 *
+	 * @param {Event} event the event which propagation to stop
+	 */
+	function eventStopPropagation(event) {
+		event = event || window.event;
+
+		if (event.stopPropagation) {
+			event.stopPropagation();
+		} else {
+			event.cancelBubble = true;
+		}
+	}
+
+	/**
+	 * Prevents the default action on an event. If the browser does not support the native
+	 * Event.preventDefault() false is returned.
+	 *
+	 * @param {Event} event the event for which the default action should be canceled
+	 * @returns {boolean} false if the browser does not support the Event.preventDefault() method
+	 */
+	function eventPreventDefault(event) {
+		// check if we can call preventDefault on the event
+		if (event && event.preventDefault) {
+			event.preventDefault();
+		} else {
+			// if the event or preventDefault() does not exist we return false
+			return false;
+		}
+	}
+
 
 	return {
 		anyRx: anyRx,
 		addEditingHelpers: addEditingHelpers,
-		removeEditingHelpers: removeEditingHelpers
+		removeEditingHelpers: removeEditingHelpers,
+		eventStopPropagation: eventStopPropagation,
+		eventPreventDefault: eventPreventDefault
 	};
 });

--- a/src/plugins/common/block/lib/block.js
+++ b/src/plugins/common/block/lib/block.js
@@ -37,6 +37,7 @@ define([
 	'aloha/observable',
 	'ui/scopes',
 	'util/class',
+	'util/misc',
 	'PubSub',
 	'block/block-utils',
 	'util/dom',
@@ -49,6 +50,7 @@ define([
 	Observable,
 	Scopes,
 	Class,
+	Misc,
 	PubSub,
 	BlockUtils,
 	Dom,
@@ -852,17 +854,7 @@ define([
 
 			// Prevent the prevention of drag inside a cell
 			var element = this.$element.get(0);
-			element.ondragstart = function (e) {
-				if (e) {
-					if (typeof e.stopPropagation === 'function') {
-						e.stopPropagation();
-					} else {
-						e.cancelBubble = true;
-					}
-				} else {
-					window.event.cancelBubble = true;
-				}
-			};
+			element.ondragstart = Misc.eventStopPropagation;
 
 			this.$element.draggable({
 				handle: '.aloha-block-draghandle',

--- a/src/plugins/common/block/lib/dragbehavior.js
+++ b/src/plugins/common/block/lib/dragbehavior.js
@@ -32,7 +32,8 @@ define([
 	'aloha/copypaste',
 	'block/block-utils',
 	'aloha/console',
-	'ui/scopes'
+	'ui/scopes',
+	'util/misc'
 ], function (
 	$,
 	Aloha,
@@ -40,7 +41,8 @@ define([
 	CopyPaste,
 	BlockUtils,
 	Console,
-	Scopes
+	Scopes,
+	Misc
 ) {
 	'use strict';
 
@@ -215,22 +217,10 @@ define([
 		var $handle = $('>.aloha-block-draghandle', this.$element);
 		var element = this.$element.get(0);
 
-		element.onselectstart = function () {
-			window.event.cancelBubble = true;
-		};
+		element.onselectstart = Misc.eventStopPropagation;
 
 		// Prevent the prevention of drag inside a cell
-		element.ondragstart = function (e) {
-			if (e) {
-				if (typeof e.stopPropagation === 'function') {
-					e.stopPropagation();
-				} else {
-					e.cancelBubble = true;
-				}
-			} else {
-				window.event.cancelBubble = true;
-			}
-		};
+		element.ondragstart = Misc.eventStopPropagation;
 
 		$handle
 			.on('mousedown', function () {

--- a/src/plugins/common/table/lib/table-cell.js
+++ b/src/plugins/common/table/lib/table-cell.js
@@ -260,9 +260,7 @@ define([
 		});
 
 		if ($elem[0]) {
-			$elem[0].onselectstart = function () {
-				return false;
-			};
+			$elem[0].onselectstart = Misc.eventPreventDefault;
 		}
 
 		$elem.on('mouseenter', function (evt) {
@@ -283,14 +281,10 @@ define([
 		if ($wrapper[0]) {
 			var wrapper = $wrapper[0];
 
-			wrapper.onselectstart = function () {
-				window.event.cancelBubble = true;
-			};
+			wrapper.onselectstart = Misc.eventStopPropagation;
 			// Disabled the dragging of content, since it makes cell selection
 			// difficult.
-			wrapper.ondragstart = function () {
-				return false
-			};
+			wrapper.ondragstart = Misc.eventPreventDefault;
 		}
 
 		return this;


### PR DESCRIPTION
In Firefox clicking into a table cell sometimes threw an error because a property on the non-standard window.event object was accessed. This has bee fixed the Aloha-Editor table plugin will now always use the event object passed to the event handler by the browser.