### PR TITLE
Update links in Guides template (fixes #1556)

### DIFF
--- a/doc/guides/source/layout.html.erb
+++ b/doc/guides/source/layout.html.erb
@@ -26,14 +26,13 @@
   <header role="banner">
     <div class="container">
       <h1 id="logo">
-        <a href="http://aloha-editor.org"><img src="images/header/logo.png" height="50" alt="Aloha Editor" /></a>
+        <a href="http://www.alohaeditor.org"><img src="images/header/logo.png" height="50" alt="Aloha Editor" /></a>
       </h1>
       <nav role="navigation">
         <ul>
-			<li><a href="http://aloha-editor.org/Content.Node/index.html#features" title="A shortcut for Aloha Editor features" class="new">Features</a></li>
-      <li class="active"><a href="http://aloha-editor.org/guides/" title="The Aloha Editor documentation">Guides</a></li>
-			<li><a href="http://getsatisfaction.com/aloha_editor" title="Get help or help others">Forum</a></li>
-			<li><a href="http://aloha-editor.org/demo" title="Feel the Aloha">Try it</a></li>
+          <li class="active"><a href="./" title="The Aloha Editor documentation">Guides</a></li>
+          <li><a href="http://getsatisfaction.com/aloha_editor" title="Get help or help others">Forum</a></li>
+          <li><a href="https://rawgit.com/alohaeditor/Aloha-Editor/dev/src/demo/boilerplate/" title="Feel the Aloha">Try it</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
Replaced the no-longer working link to the demo with a rawgit link as per @balupton’s suggestion.

The ‘guides’ link can be relative as it refers to itself.

Also removed a link to no longer existing features page.
