### PR TITLE
Omit content sniffing in wordcontenthandler when running in Edge

### DIFF
--- a/build/changelog/entries/2017/06/11916.SUP-3131.bugfix
+++ b/build/changelog/entries/2017/06/11916.SUP-3131.bugfix
@@ -1,0 +1,3 @@
+paste-plugin: When pasting content from Word to Edge, the paste plugin failed to detect and transform
+Word specific formatting due to missing classes. The wordcontenthandler is now modified to always treat content
+as if coming from Word when used in Edge.

--- a/src/lib/aloha/core.js
+++ b/src/lib/aloha/core.js
@@ -681,7 +681,8 @@ define([
 			function uaMatch(ua) {
 				ua = ua.toLowerCase();
 
-				var match = /(chrome)[ \/]([\w.]+)/.exec(ua) ||
+				var match = /(edge)[ \/]([\w.]+)/.exec(ua) ||
+					/(chrome)[ \/]([\w.]+)/.exec(ua) ||
 					/(webkit)[ \/]([\w.]+)/.exec(ua) ||
 					/(opera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) ||
 					/(msie) ([\w.]+)/.exec(ua) ||

--- a/src/plugins/common/contenthandler/lib/wordcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/wordcontenthandler.js
@@ -119,6 +119,11 @@ define([
 	 *         office document.
 	 */
 	function isWordContent($content) {
+		// Edge does not paste the mso classes anymore, so we need to treat everything
+		// as if coming from word
+		if (Aloha.browser.edge) {
+			return true;
+		}
 		// Because reading the html of the content is way faster than iterating
 		// its entire node tree, therefore we attempt this first.
 		if (0 === $content.length || !MSO.test($content[0].outerHTML)) {


### PR DESCRIPTION
When pasting content from Word into Edge, the HTML is missing mso
classes, which are used to detect Word content. Therefore, content
always needs to be treated as coming from Word when pasted into Edge.