### PR TITLE
Fix scrolling when formatting a table caption in Internet Explorer

### DIFF
--- a/build/changelog/entries/2017/10/12152.SUP-5043.bugfix
+++ b/build/changelog/entries/2017/10/12152.SUP-5043.bugfix
@@ -1,0 +1,2 @@
+format plugin: When changing the formatting on block-level inside a table caption in Internet Explorer the browser scrolled to the beginning of the editable. This has been fixed.
+

--- a/src/plugins/common/format/lib/format-plugin.js
+++ b/src/plugins/common/format/lib/format-plugin.js
@@ -294,7 +294,7 @@ define('format/format-plugin', [
 		formatPlugin.changeMarkup( button );
 
 		// setting the focus is needed for mozilla to have a working rangeObject.select()
-		if (Aloha.activeEditable && jQuery.browser.mozilla && document.activeElement !== Aloha.activeEditable.obj[0]) {
+		if (Aloha.activeEditable && Aloha.browser.mozilla && document.activeElement !== Aloha.activeEditable.obj[0]) {
 			Aloha.activeEditable.obj.focus();
 		}
 		


### PR DESCRIPTION
When changing the formatting in a table caption in Internet Explorer, the browser scrolled to the top of the editable. This has been fixed.
SUP-5043