### PR TITLE
Fix cell splitting

### DIFF
--- a/build/changelog/entries/2018/01/12241.bugfix
+++ b/build/changelog/entries/2018/01/12241.bugfix
@@ -1,0 +1,1 @@
+Merged table cells could not be split when they where marked as table headers. Also the @aloha-smart-content-changed@ event was not triggered properly when cells where merged or splitted. These issures have been fixed.

--- a/src/plugins/common/table/lib/table-plugin-utils.js
+++ b/src/plugins/common/table/lib/table-plugin-utils.js
@@ -39,6 +39,31 @@ define([
 
 	var Utils = {
 		/**
+		 * Creates markup for the jQuery constructor to create a copy of
+		 * the specified cell.
+		 *
+		 * The cell type (td or th) as well as the classes are copied.
+		 *
+		 * @param cell The original table cell to copy
+		 * @return A string containing markup for the copied from the specified cell
+		 */
+		'copyCellMarkup': function (cell) {
+			if (!cell) {
+				return '<td></td>';
+			}
+
+			var nodeName = cell.nodeName.toLowerCase();
+			var classes = cell.classList;
+
+			if (classes) {
+				classes.remove('aloha-cell-selected');
+				return '<' + nodeName + ' class="' + classes + '"></' + nodeName + '>';
+			}
+
+			return '<' + nodeName + '></' + nodeName + '>';
+		},
+
+		/**
 		 * Translates the DOM-Element column offset of a table-cell to the
 		 * column offset of a grid-cell, which is the column index adjusted
 		 * by other cells' rowspan and colspan values.

--- a/src/plugins/common/table/lib/table-plugin.js
+++ b/src/plugins/common/table/lib/table-plugin.js
@@ -680,8 +680,11 @@ define([
 						activeCell = TablePlugin.selectedOrActiveCells();
 						if (activeCell.length > 0) {
 							Utils.splitCell(activeCell, function () {
-								return TablePlugin.activeTable.newActiveCell().obj;
+								return TablePlugin.activeTable.newActiveCell(Utils.copyCellMarkup(activeCell[0])).obj;
 							});
+
+
+							Aloha.activeEditable.smartContentChange({type: 'block-change', plugin: 'table-plugin'});
 							Aloha.trigger('aloha-table-selection-changed');
 						}
 					}
@@ -1601,10 +1604,12 @@ define([
 		// set the active cell as the selected cell.
 		if (!sc || sc.length < 1) {
 			var activeCell = function() {
-			var range = Aloha.Selection.getRangeObject();
+				var range = Aloha.Selection.getRangeObject();
 				if (Aloha.activeEditable) {
 					return range.findMarkup( function() {
-							return this.nodeName.toLowerCase() === 'td';
+						var nodeName = this.nodeName.toLowerCase();
+
+						return nodeName === 'td' || nodeName === 'th';
 					}, Aloha.activeEditable.obj );
 				} else {
 					return null;

--- a/src/plugins/common/table/lib/table-selection.js
+++ b/src/plugins/common/table/lib/table-selection.js
@@ -395,6 +395,8 @@ define([
 		this.selectionType = 'cell';
 
 		Aloha.trigger( 'aloha-table-selection-changed' );
+
+		Aloha.activeEditable.smartContentChange({type: 'block-change', plugin: 'table-plugin'});
 	};
 
 	/**
@@ -410,8 +412,10 @@ define([
 		if (cells_to_split.length > 0) {
 
 			$(cells_to_split).each(function(){
+				var cell = this;
+
 				Utils.splitCell(this, function () {
-					return selection.table.newActiveCell().obj;
+					return selection.table.newActiveCell(Utils.copyCellMarkup(cell)).obj;
 				});
 			});
 
@@ -422,6 +426,7 @@ define([
 			this.selectionType = 'cell';
 
 			Aloha.trigger( 'aloha-table-selection-changed' );
+			Aloha.activeEditable.smartContentChange({type: 'block-change', plugin: 'table-plugin'});
 		}
 	};
 


### PR DESCRIPTION
Table header cells can now be split again and any classes of the merged cell
are copied to the split cells. Also the aloha-smart-content-changed event
is triggered when cells are merged or splitted.

OSUU-169