### PR TITLE
SUP-6294: Do not remove class attributes on ul and ol elements

### DIFF
--- a/build/changelog/entries/2018/06/12499.SUP-6294.bufix
+++ b/build/changelog/entries/2018/06/12499.SUP-6294.bufix
@@ -1,0 +1,3 @@
+When using copy and paste to insert text: class attributes on list elements (ul, ol) where removed per default. This caused 
+styling which users added via Aloha-Editor to lists to be lost when pasting a list. This fix will preserve the class attributes 
+on list elements per default.

--- a/src/plugins/common/contenthandler/lib/genericcontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/genericcontenthandler.js
@@ -307,16 +307,22 @@ define([
 		removeStyles: function (content) {
 			var that = this;
 
-			// completely remove style tags
-			content.children('style').filter(function () {
-				return this.contentEditable !== 'false';
-			}).remove();
+			var filteredChildren = content.children()
+				.filter(function () {
+					return this.contentEditable !== 'false' && notAlohaBlockFilter(this);
+				})
+				.not('.aloha-block');
 
-			// remove style attributes and classes
-			content.children().filter(notAlohaBlockFilter).not('.aloha-block').filter(function () {
-				return this.contentEditable !== 'false';
-			}).each(function () {
-				$(this).removeAttr('style').removeClass();
+			// completely remove style tags
+			filteredChildren.find('style').remove();
+
+			filteredChildren
+				.removeAttr('style')
+				// don't remove classes on ul or ol elements
+				.not('ul,ol')
+				.removeClass();
+
+			filteredChildren.each(function () {
 				that.removeStyles($(this));
 			});
 		},

--- a/src/plugins/common/contenthandler/lib/sanitizecontenthandler.js
+++ b/src/plugins/common/contenthandler/lib/sanitizecontenthandler.js
@@ -91,14 +91,14 @@ function ( Aloha, jQuery, ContentHandlerManager, Plugin, console ) {
 			'col': ['span', 'width'],
 			'colgroup': ['span', 'width'],
 			'img': ['align', 'alt', 'height', 'src', 'title', 'width', 'class', 'data-caption', 'data-align', 'data-width', 'data-original-image'],
-			'ol': ['start', 'type'],
+			'ol': ['start', 'type', 'class'],
 			'p': ['class', 'style', 'id'],
 			'q': ['cite'],
 			'table': ['summary', 'width'],
 									// For IE7 it matters the uppercase 'S' in rowSpan, colSpan
 			'td': ['abbr', 'axis', 'colSpan', 'rowSpan', 'colspan', 'rowspan', 'width'],
 			'th': ['abbr', 'axis', 'colSpan', 'rowSpan', 'colspan', 'rowspan', 'scope', 'width'],
-			'ul': ['type'],
+			'ul': ['type', 'class'],
 			'span': ['class','style','lang','xml:lang','role']
 		},
 


### PR DESCRIPTION
When using copy and paste to insert text: class attributes on list elements (ul, ol) where removed per default. This caused styling which users added via Aloha-Editor to lists to be lost when pasting a list. This fix will preserve the class attributes on list elements per default.