### PR TITLE
Extend the Empty-Link-Checker for for links starting with "https" 

### DIFF
--- a/src/plugins/extra/emptylink/css/emptylink.css
+++ b/src/plugins/extra/emptylink/css/emptylink.css
@@ -1,16 +1,18 @@
 /* mark all anchor elements without name and href attribute */
 .aloha-editable.aloha-emptylink-plugin a:not([name]):not([href]),
-/* mark all anchor elements with empty href attribute (including '#') and the name and data-gentics-aloha-object-id attributes not set */
+	/* mark all anchor elements with empty href attribute (including '#') and the name and data-gentics-aloha-object-id attributes not set */
 .aloha-editable.aloha-emptylink-plugin a[href='#']:not([name]):not([data-gentics-aloha-object-id]),
 .aloha-editable.aloha-emptylink-plugin a[href='']:not([name]):not([data-gentics-aloha-object-id]),
 .aloha-editable.aloha-emptylink-plugin a[href='http://']:not([name]):not([data-gentics-aloha-object-id]),
-/* mark all anchor elements with empty name attribute and the href attribute not set */
+.aloha-editable.aloha-emptylink-plugin a[href='https://']:not([name]):not([data-gentics-aloha-object-id]),
+	/* mark all anchor elements with empty name attribute and the href attribute not set */
 .aloha-editable.aloha-emptylink-plugin a[name='']:not([href]),
-/* mark all anchor elements with empty href (including '#') and empty name attribute */
+	/* mark all anchor elements with empty href (including '#') and empty name attribute */
 .aloha-editable.aloha-emptylink-plugin a[href='#'][name=''],
 .aloha-editable.aloha-emptylink-plugin a[href='http://'][name=''],
+.aloha-editable.aloha-emptylink-plugin a[href='https://'][name=''],
 .aloha-editable.aloha-emptylink-plugin a[href=''][name=''],
-/* mark all anchor elements that are marked to link to offline data-gentics-aloha-objects */
+	/* mark all anchor elements that are marked to link to offline data-gentics-aloha-objects */
 .aloha-editable.aloha-emptylink-plugin a[data-gentics-aloha-object-online='false'] {
 	background-color: red;
 }

--- a/src/plugins/extra/emptylink/css/emptylink.css
+++ b/src/plugins/extra/emptylink/css/emptylink.css
@@ -1,18 +1,18 @@
 /* mark all anchor elements without name and href attribute */
 .aloha-editable.aloha-emptylink-plugin a:not([name]):not([href]),
-	/* mark all anchor elements with empty href attribute (including '#') and the name and data-gentics-aloha-object-id attributes not set */
+/* mark all anchor elements with empty href attribute (including '#') and the name and data-gentics-aloha-object-id attributes not set */
 .aloha-editable.aloha-emptylink-plugin a[href='#']:not([name]):not([data-gentics-aloha-object-id]),
 .aloha-editable.aloha-emptylink-plugin a[href='']:not([name]):not([data-gentics-aloha-object-id]),
 .aloha-editable.aloha-emptylink-plugin a[href='http://']:not([name]):not([data-gentics-aloha-object-id]),
 .aloha-editable.aloha-emptylink-plugin a[href='https://']:not([name]):not([data-gentics-aloha-object-id]),
-	/* mark all anchor elements with empty name attribute and the href attribute not set */
+/* mark all anchor elements with empty name attribute and the href attribute not set */
 .aloha-editable.aloha-emptylink-plugin a[name='']:not([href]),
-	/* mark all anchor elements with empty href (including '#') and empty name attribute */
+/* mark all anchor elements with empty href (including '#') and empty name attribute */
 .aloha-editable.aloha-emptylink-plugin a[href='#'][name=''],
 .aloha-editable.aloha-emptylink-plugin a[href='http://'][name=''],
 .aloha-editable.aloha-emptylink-plugin a[href='https://'][name=''],
 .aloha-editable.aloha-emptylink-plugin a[href=''][name=''],
-	/* mark all anchor elements that are marked to link to offline data-gentics-aloha-objects */
+/* mark all anchor elements that are marked to link to offline data-gentics-aloha-objects */
 .aloha-editable.aloha-emptylink-plugin a[data-gentics-aloha-object-online='false'] {
 	background-color: red;
 }


### PR DESCRIPTION
Now the emptylink-plugin should find and highlight empty Links starting with "https://". 