### PR TITLE
Fix confirmed delete of a block to only ask for confirmation, if the

### DIFF
--- a/build/changelog/entries/2022/12527.SUP-10337.bugfix
+++ b/build/changelog/entries/2022/12527.SUP-10337.bugfix
@@ -1,0 +1,4 @@
+When nesting editables into blocks, which were nested into other blocks, in some situations, pressing the "delete" or "forwarddelete" key
+would call the confirmedDestroy() method of the inner block (which would show a dialog to ask, whether the block should be deleted),
+although the shouldDestroy() method of the block returned false (effectively preventing the block from being deleted).
+This has been fixed now, so that confirmedDestroy() is only called, when the block actually can be deleted (shouldDestroy() returns true).

--- a/src/plugins/common/block/lib/blockmanager.js
+++ b/src/plugins/common/block/lib/blockmanager.js
@@ -274,11 +274,14 @@ define([
 				var isDeleteOperation = 'delete' === cmd || 'forwarddelete' === cmd;
 
 				if (that._activeBlock && isDeleteOperation && isOnlyBlockSelected) {
-					that._activeBlock.confirmedDestroy( function () {
-						// In this case, the default command shall not be executed.
-						data.preventDefault = true;
-						that._activeBlock.destroy();
-					});
+					// only ask whether the block shall be destroyed, if it actually can be destroyed
+					if (that._activeBlock.shouldDestroy()) {
+						that._activeBlock.confirmedDestroy( function () {
+							// In this case, the default command shall not be executed.
+							data.preventDefault = true;
+							that._activeBlock.destroy();
+						});
+					}
 				} else if (
 					!that._activeBlock &&
 					isDeleteOperation &&


### PR DESCRIPTION
block actually can be deleted.